### PR TITLE
remove related milestone section from task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -27,12 +27,6 @@ assignees: ''
 ## ⚠️ Risks & Mitigations
 <!-- Known risks, edge cases, rollbacks -->
 
-## 📊 Meta (optional)
-- Priority: <!-- P0 / P1 / P2 -->
-- Area: <!-- Frontend / Backend / API / Infra / UX -->
-- Size: <!-- 1 / 2 / 3 / 5 / 8 -->
-- Iteration: <!-- Sprint X -->
-
 ## 💬 Notes
 <!-- Additional context, links, designs, etc. -->
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -9,9 +9,6 @@ assignees: ''
 ## 🎯 Goal & Description
 <!-- What needs to be done? Brief and clear description. -->
 
-## 🔗 Related Milestone
-- Milestone: <!-- e.g., Sprint 4 -->
-
 ## 🧩 Subtasks (if applicable)
 - [ ] Step 1
 - [ ] Step 2


### PR DESCRIPTION
This pull request makes a small update to the issue template by removing the "Related Milestone" section. This simplifies the template and reduces required metadata for new tasks.