### PR TITLE
feat(not_found): Adding a layout for 404 error

### DIFF
--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { Geist, Geist_Mono, Bowlby_One } from 'next/font/google';
+import Navigation from '@/components/Navigation';
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const bowlbyOne = Bowlby_One({
+  variable: "--font-bowlby-one",
+  subsets: ["latin"],
+  weight: "400",
+});
+
+export default function Custom404() {
+  return (
+    <div className="h-screen flex flex-col w-full">
+      <Navigation/>
+      <div className={`flex-1 bg-gradient-to-br from-blue-50 to-indigo-100 text-white flex items-center justify-center px-4 ${geistSans.variable} ${geistMono.variable} ${bowlbyOne.variable}`}>
+        <div className="text-center">
+          <h1 className={`text-[120px] md:text-[180px] font-bold text-blue-600 mb-1 ${bowlbyOne.className}`}>
+            404
+          </h1>
+          <p className={`text-xl ${geistMono.className} text-blue-600`}>Page not found</p>
+          <div className="mt-12">
+            <Link 
+              href="/" 
+              className={`bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-6 rounded-full transition duration-300 ${geistSans.className}`}
+            >
+              Back to menu
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new custom 404 "Page Not Found" component for the frontend. The new page features a styled layout, custom fonts, and a navigation link back to the main menu for improved user experience.

User experience improvements:

* Added a custom 404 page in `not-found.tsx` with a prominent "404" message, styled background, and a button linking back to the homepage.
* Integrated Google fonts (`Geist`, `Geist_Mono`, `Bowlby_One`) for enhanced typography on the 404 page.
* Included the main `Navigation` component at the top of the 404 page for consistent site navigation.