### PR TITLE
Add ci/cd

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run tests with pytest
         run: |
-          pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=xml || true
+          pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=xml
         continue-on-error: false
 
       - name: Upload coverage report

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -7,7 +7,7 @@ on:
       - 'backend/**'
       - '.github/workflows/backend-ci.yml'
   push:
-    branches: [main]
+    branches: ['**']
     paths:
       - 'backend/**'
       - '.github/workflows/backend-ci.yml'

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,6 +34,7 @@ jobs:
       DJANGO_SECRET_KEY: "github-actions-test-key"
       DJANGO_SQLITE_PRAGMAS: "{'foreign_keys': 1}"
       DJANGO_TEST_DB_PATH: "/tmp/test-db.sqlite3"
+      DISABLE_SCHEDULER: "True"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,6 +35,9 @@ jobs:
       DJANGO_SQLITE_PRAGMAS: "{'foreign_keys': 1}"
       DJANGO_TEST_DB_PATH: "/tmp/test-db.sqlite3"
       DISABLE_SCHEDULER: "True"
+      DJANGO_ADMIN_USERNAME: "admin"
+      DJANGO_ADMIN_EMAIL: "admin@example.com"
+      DJANGO_ADMIN_PASSWORD: "admin-ci-test-password"
 
     steps:
       - name: Checkout repository

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ be-format:
 	cd backend && black .
 
 be-test:
-	cd backend && pytest -q --cov=.
+	cd backend && DISABLE_SCHEDULER=True pytest -q --disable-warnings --cov=. --cov-report=xml
 
 # Docker commands
 docker-build:

--- a/backend/admin_panel/tests.py
+++ b/backend/admin_panel/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/admin_panel/tests/test_models.py
+++ b/backend/admin_panel/tests/test_models.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+
+from admin_panel.models import Event, News, StartupList
+
+
+class SimpleTestCase(TestCase):
+    def test_models_exist(self):
+        """Simple test to verify models can be imported"""
+        assert News is not None
+        assert Event is not None
+        assert StartupList is not None

--- a/backend/exposed_api/tests.py
+++ b/backend/exposed_api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/init/apps.py
+++ b/backend/init/apps.py
@@ -21,8 +21,7 @@ class InitConfig(AppConfig):
 
         import init.signals
 
-        # Only start scheduler in the main process (RUN_MAIN is set by Django in the child process)
-        # Also check if scheduler is disabled (for tests)
+        # Only start scheduler in the main process and if not disabled by environment variables (for tests)
         if os.environ.get("RUN_MAIN") != "true" and os.environ.get("DISABLE_SCHEDULER") != "True":
             from init.scheduler import start_scheduler
 

--- a/backend/init/apps.py
+++ b/backend/init/apps.py
@@ -22,7 +22,8 @@ class InitConfig(AppConfig):
         import init.signals
 
         # Only start scheduler in the main process (RUN_MAIN is set by Django in the child process)
-        if os.environ.get("RUN_MAIN") != "true":
+        # Also check if scheduler is disabled (for tests)
+        if os.environ.get("RUN_MAIN") != "true" and os.environ.get("DISABLE_SCHEDULER") != "True":
             from init.scheduler import start_scheduler
 
             start_scheduler()

--- a/backend/init/scheduler.py
+++ b/backend/init/scheduler.py
@@ -87,6 +87,7 @@ def start_scheduler():
     def safe_shutdown():
         if scheduler:
             import contextlib
+
             with contextlib.suppress(Exception):
                 scheduler.shutdown()
 

--- a/backend/init/scheduler.py
+++ b/backend/init/scheduler.py
@@ -82,7 +82,15 @@ def start_scheduler():
     # Start the scheduler in a daemon thread
     scheduler.start()
     logger.info(f"API Data Sync Scheduler initialized (interval: {interval_minutes}m)")
-    atexit.register(lambda: scheduler.shutdown() if scheduler else None)
+
+    # Register a safer shutdown function that handles errors
+    def safe_shutdown():
+        if scheduler:
+            import contextlib
+            with contextlib.suppress(Exception):
+                scheduler.shutdown()
+
+    atexit.register(safe_shutdown)
 
     if fetch_on_startup:
         thread = threading.Thread(target=fetch_all_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,4 +188,5 @@ testpaths = ["backend"]
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::django.utils.deprecation.RemovedInDjango60Warning",
+    "ignore:pkg_resources is deprecated as an API:UserWarning",
 ]


### PR DESCRIPTION
This pull request introduces several improvements to the backend testing workflow and scheduler management. The main focus is on making test runs more reliable by disabling the scheduler during tests, improving the scheduler's shutdown process, and ensuring that model imports are tested. Additionally, the CI workflow is updated to run on all branches and to use more robust environment variables for testing.

**Testing and CI workflow improvements:**

* The GitHub Actions workflow `.github/workflows/backend-ci.yml` is updated to trigger on pushes to any branch (instead of just `main`) and to set environment variables for disabling the scheduler and providing admin credentials during tests. The test step now fails on test failures instead of always succeeding. [[1]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL10-R10) [[2]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bR37-R40) [[3]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL68-R72)
* The `Makefile` test command and the test workflow now set `DISABLE_SCHEDULER=True` to prevent the scheduler from running during tests, and add `--disable-warnings` and coverage reporting to the `pytest` command for cleaner test output.

**Scheduler reliability:**

* The scheduler is now only started if both `RUN_MAIN` is not `"true"` and `DISABLE_SCHEDULER` is not `"True"`, ensuring it doesn't interfere with test runs.
* The scheduler's shutdown function is now wrapped in a `contextlib.suppress(Exception)` block to prevent shutdown errors from causing issues during process exit.

**Testing improvements:**

* Removed empty placeholder test files and added a basic test in `backend/admin_panel/tests/test_models.py` to verify that core models can be imported. [[1]](diffhunk://#diff-e0f88eaa421dad8a8fcb4c25045754513223c9da7f1f9402608ecfe83ee7b300L1-L3) [[2]](diffhunk://#diff-07f7a6e2589fb1b0db6378d9f42b5ceb8a6ab8bc7ef583055d3db8da4b6444c6R1-R11) [[3]](diffhunk://#diff-e0f88eaa421dad8a8fcb4c25045754513223c9da7f1f9402608ecfe83ee7b300L1-L3)
* Added a filter to suppress a specific deprecation warning in `pyproject.toml` for cleaner test logs.