### PR TITLE
BACKEND FIX - projects GET views permissions

### DIFF
--- a/backend/exposed_api/project_views.py
+++ b/backend/exposed_api/project_views.py
@@ -17,9 +17,31 @@ class IsAdminUser(permissions.BasePermission):
 
 
 class ProjectDetailView(APIView):
-    permission_classes = [IsAdminUser]
+    def get_permissions(self):
+        """
+        Override to return different permissions based on HTTP method.
+        GET requests are allowed for everyone, but POST, PUT, DELETE require admin.
+        """
+        if self.request.method == 'GET':
+            return [AllowAny()]
+        return [IsAdminUser()]
+
+    def get(self, request, _id=None):
+        """Handle GET requests - accessible to all users"""
+        if _id is None:
+            startups = StartupDetail.objects.all()
+            serializer = ProjectSerializer(startups, many=True)
+            return JsonResponse(serializer.data, safe=False)
+        else:
+            try:
+                startup = StartupDetail.objects.get(id=_id)
+                serializer = ProjectDetailSerializer(startup)
+                return JsonResponse(serializer.data)
+            except StartupDetail.DoesNotExist:
+                return JsonResponse({"error": f"Project with id {_id} not found"}, status=status.HTTP_404_NOT_FOUND)
 
     def post(self, request):
+        """Handle POST requests - admin only"""
         serializer = ProjectSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
@@ -27,6 +49,7 @@ class ProjectDetailView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def put(self, request, _id):
+        """Handle PUT requests - admin only"""
         project = get_object_or_404(StartupDetail, id=_id)
         serializer = ProjectSerializer(project, data=request.data, partial=False)
         if serializer.is_valid():
@@ -35,28 +58,7 @@ class ProjectDetailView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, _id):
+        """Handle DELETE requests - admin only"""
         project = get_object_or_404(StartupDetail, id=_id)
         project.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
-
-
-# GET views for projects (public)
-
-
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def projects_list(request):
-    startups = StartupDetail.objects.all()
-    serializer = ProjectSerializer(startups, many=True)
-    return JsonResponse(serializer.data, safe=False)
-
-
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def project_detail(request, project_id):
-    try:
-        startup = StartupDetail.objects.get(id=project_id)
-        serializer = ProjectDetailSerializer(startup)
-        return JsonResponse(serializer.data)
-    except StartupDetail.DoesNotExist:
-        return JsonResponse({"error": f"Project with id {project_id} not found"}, status=status.HTTP_404_NOT_FOUND)

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -7,16 +7,13 @@ app_name = "exposed_api"
 
 
 urlpatterns = [
-    # Project CRUD (admin only)
-    path("projects/", project_views.ProjectDetailView.as_view(), name="project_create"),  # POST (create)
-    path("projects/<int:id>", project_views.ProjectDetailView.as_view(), name="project_crud"),  # PUT, DELETE
-    # Project GETs (public)
-    path("projects/", project_views.projects_list, name="projects_list"),
-    path("projects/<int:project_id>/", project_views.project_detail, name="project_detail"),
+    # Project endpoints
+    path("projects/", project_views.ProjectDetailView.as_view(), name="project_create_or_list"),
+    path("projects/<int:_id>/", project_views.ProjectDetailView.as_view(), name="project_detail_or_crud"),
+    # Events endpoint
+    path("events/", EventListView.as_view(), name="events_list"),
     # Other endpoints
     path("user/<int:user_id>/", views.user_detail, name="user_detail"),
     path("projectViews/<int:user_id>/", views.project_views, name="project_views"),
     path("projectEngagement/<int:user_id>/", views.project_engagement, name="project_engagement"),
-    # Events endpoint
-    path("events/", EventListView.as_view(), name="events_list"),
 ]


### PR DESCRIPTION
This pull request refactors the project-related API endpoints to consolidate logic into a single class-based view, improving maintainability and permission handling. The changes remove redundant function-based views, unify CRUD and list/detail operations, and implement method-specific permissions so that GET requests are public while modifications remain admin-only.

Project API refactor and permission improvements:

* Refactored `ProjectDetailView` to handle all project-related endpoints (`GET`, `POST`, `PUT`, `DELETE`) with method-specific permissions: `GET` is public, while other methods require admin privileges. Added docstrings for clarity.
* Removed redundant function-based views (`projects_list`, `project_detail`) and their corresponding URL patterns, consolidating all project endpoints into the class-based view. [[1]](diffhunk://#diff-a80aaf5df8014aa3593b753f23f70afeb4ec7870354cecac24a338c15a82e22eR61-L62) [[2]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bL10-L21)
* Updated URL patterns in `urls.py` to route both list/create and detail/CRUD project requests to the new unified class-based view, simplifying the API surface.