### PR TITLE
BACKEND FIX - event route

### DIFF
--- a/backend/exposed_api/event_views.py
+++ b/backend/exposed_api/event_views.py
@@ -1,4 +1,5 @@
-from rest_framework import status
+from rest_framework import permissions, status
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -7,7 +8,21 @@ from admin_panel.models import Event
 from .event_serializers import EventSerializer
 
 
+class IsAdminUser(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user and request.user.is_staff
+
+
 class EventListView(APIView):
+    def get_permissions(self):
+        """
+        Override to return different permissions based on HTTP method.
+        GET requests are allowed for everyone, but POST, PUT, DELETE require admin.
+        """
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return [IsAdminUser()]
+
     def get(self, request):
         events = Event.objects.all()
         serializer = EventSerializer(events, many=True)


### PR DESCRIPTION
This pull request updates the permissions logic for the `EventListView` in `event_views.py` to better control access based on user roles and request methods. Now, anyone can perform GET requests, but only admin users can perform POST, PUT, or DELETE requests.

**Permissions logic improvements:**

* Added a custom `IsAdminUser` permission class to restrict non-GET requests to admin users.
* Overrode the `get_permissions` method in `EventListView` to allow all users to perform GET requests while requiring admin privileges for other HTTP methods.

**Imports update:**

* Updated imports to include `permissions` and `AllowAny` from `rest_framework.permissions`.