### PR TITLE
BACKEND - GET user route and fixes

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -34,5 +34,4 @@ urlpatterns = [
     path("api/auth/", include("authentication.urls")),  # Authentication endpoints
 ]
 
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/exposed_api/event_serializers.py
+++ b/backend/exposed_api/event_serializers.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from rest_framework import serializers
+import os
 
 from admin_panel.models import Event
 
@@ -21,5 +23,5 @@ class EventSerializer(serializers.ModelSerializer):
 
     def get_pictureURL(self, obj):
         if obj.image:
-            return f"/media/events/{obj.image}"
+            return os.path.join(settings.MEDIA_URL.rstrip('/'), 'events', obj.image)
         return None

--- a/backend/exposed_api/event_serializers.py
+++ b/backend/exposed_api/event_serializers.py
@@ -24,5 +24,5 @@ class EventSerializer(serializers.ModelSerializer):
 
     def get_pictureURL(self, obj):
         if obj.image:
-            return os.path.join(settings.MEDIA_URL.rstrip("/"), "events", obj.image)
+            return os.path.join(settings.MEDIA_URL.rstrip("/"), obj.image)
         return None

--- a/backend/exposed_api/event_serializers.py
+++ b/backend/exposed_api/event_serializers.py
@@ -1,6 +1,7 @@
+import os
+
 from django.conf import settings
 from rest_framework import serializers
-import os
 
 from admin_panel.models import Event
 
@@ -23,5 +24,5 @@ class EventSerializer(serializers.ModelSerializer):
 
     def get_pictureURL(self, obj):
         if obj.image:
-            return os.path.join(settings.MEDIA_URL.rstrip('/'), 'events', obj.image)
+            return os.path.join(settings.MEDIA_URL.rstrip("/"), "events", obj.image)
         return None

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from . import project_views, views
+from . import project_views, user_views, views
 from .event_views import EventListView
 
 app_name = "exposed_api"
@@ -12,8 +12,10 @@ urlpatterns = [
     path("projects/<int:_id>/", project_views.ProjectDetailView.as_view(), name="project_detail_or_crud"),
     # Events endpoint
     path("events/", EventListView.as_view(), name="events_list"),
+    # User endpoints
+    path("user/", user_views.get_current_user, name="current_user"),
+    path("user/<int:user_id>/", user_views.user_detail, name="user_detail"),
     # Other endpoints
-    path("user/<int:user_id>/", views.user_detail, name="user_detail"),
     path("projectViews/<int:user_id>/", views.project_views, name="project_views"),
     path("projectEngagement/<int:user_id>/", views.project_engagement, name="project_engagement"),
 ]

--- a/backend/exposed_api/user_views.py
+++ b/backend/exposed_api/user_views.py
@@ -1,20 +1,50 @@
 from authentication.models import CustomUser
+from django.conf import settings
 from django.http import JsonResponse
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from authentication.serializers import UserSerializer as AuthUserSerializer
 from .serializers import UserSerializer
+
+
+class CurrentUserSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the current authenticated user
+    """
+    role = serializers.CharField()
+    startupId = serializers.SerializerMethodField()
+    founderId = serializers.IntegerField(source='founder_id', allow_null=True)
+    userImage = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CustomUser
+        fields = ['name', 'email', 'role', 'id', 'founderId', 'startupId', 'userImage']
+
+    def get_startupId(self, obj):
+        if obj.role == 'founder' and obj.founder_id:
+            try:
+                from admin_panel.models import Founder
+                founder = Founder.objects.filter(id=obj.founder_id).first()
+                if founder:
+                    return founder.startup_id
+            except Exception:
+                pass
+        return None
+
+    def get_userImage(self, obj):
+        if obj.image:
+            return f"{settings.MEDIA_URL}{obj.image}"
+        return None
 
 
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def get_current_user(request):
     """
-    Get currently authenticated user details
+    Get currently authenticated user details in the required format
     """
-    serializer = AuthUserSerializer(request.user)
+    serializer = CurrentUserSerializer(request.user)
     return Response(serializer.data)
 
 

--- a/backend/exposed_api/user_views.py
+++ b/backend/exposed_api/user_views.py
@@ -5,6 +5,7 @@ from rest_framework import serializers, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+
 from .serializers import UserSerializer
 
 
@@ -12,19 +13,21 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     """
     Serializer for the current authenticated user
     """
+
     role = serializers.CharField()
     startupId = serializers.SerializerMethodField()
-    founderId = serializers.IntegerField(source='founder_id', allow_null=True)
+    founderId = serializers.IntegerField(source="founder_id", allow_null=True)
     userImage = serializers.SerializerMethodField()
 
     class Meta:
         model = CustomUser
-        fields = ['name', 'email', 'role', 'id', 'founderId', 'startupId', 'userImage']
+        fields = ["name", "email", "role", "id", "founderId", "startupId", "userImage"]
 
     def get_startupId(self, obj):
-        if obj.role == 'founder' and obj.founder_id:
+        if obj.role == "founder" and obj.founder_id:
             try:
                 from admin_panel.models import Founder
+
                 founder = Founder.objects.filter(id=obj.founder_id).first()
                 if founder:
                     return founder.startup_id

--- a/backend/exposed_api/user_views.py
+++ b/backend/exposed_api/user_views.py
@@ -1,0 +1,32 @@
+from authentication.models import CustomUser
+from django.http import JsonResponse
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from authentication.serializers import UserSerializer as AuthUserSerializer
+from .serializers import UserSerializer
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def get_current_user(request):
+    """
+    Get currently authenticated user details
+    """
+    serializer = AuthUserSerializer(request.user)
+    return Response(serializer.data)
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def user_detail(request, user_id):
+    """
+    API endpoint that returns information about a specific user.
+    """
+    try:
+        user = CustomUser.objects.get(id=user_id)
+    except CustomUser.DoesNotExist:
+        return JsonResponse({"error": f"User with id {user_id} not found"}, status=status.HTTP_404_NOT_FOUND)
+    serializer = UserSerializer(user)
+    return JsonResponse(serializer.data)

--- a/backend/exposed_api/views.py
+++ b/backend/exposed_api/views.py
@@ -1,9 +1,7 @@
-from authentication.models import CustomUser
 from authentication.permissions import IsAdmin, IsFounder, IsInvestor, IsNotRegularUser
-from django.http import JsonResponse
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from admin_panel.models import StartupDetail
@@ -13,7 +11,6 @@ from .serializers import (
     ProjectEngagementSerializer,
     ProjectSerializer,
     ProjectViewsSerializer,
-    UserSerializer,
 )
 
 
@@ -26,20 +23,6 @@ class IsAuthenticatedNotRegularUser(IsAuthenticated):
         if not super().has_permission(request, view):
             return False
         return request.user.role != "user"
-
-
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def user_detail(request, user_id):
-    """
-    API endpoint that returns information about a specific user.
-    """
-    try:
-        user = CustomUser.objects.get(id=user_id)
-    except CustomUser.DoesNotExist:
-        return JsonResponse({"error": f"User with id {user_id} not found"}, status=status.HTTP_404_NOT_FOUND)
-    serializer = UserSerializer(user)
-    return JsonResponse(serializer.data)
 
 
 @api_view(["GET"])

--- a/backend/init/utils.py
+++ b/backend/init/utils.py
@@ -73,6 +73,7 @@ def fetch_and_create_news():
         params = settings.JEB_API_DEFAULT_PARAMS
         headers = {**settings.JEB_API_HEADERS, "X-Group-Authorization": jeb_token}
 
+        print("\tFetching news from JEB API...")
         response = requests.get(url, params=params, headers=headers)
         response.raise_for_status()
         news_data = response.json()
@@ -114,6 +115,7 @@ def fetch_and_create_events():
         params = settings.JEB_API_DEFAULT_PARAMS
         headers = {**settings.JEB_API_HEADERS, "X-Group-Authorization": jeb_token}
 
+        print("\tFetching events from JEB API...")
         response = requests.get(url, params=params, headers=headers)
         response.raise_for_status()
         events_data = response.json()
@@ -242,6 +244,7 @@ def fetch_and_create_startups():
         params = settings.JEB_API_DEFAULT_PARAMS
         headers = {**settings.JEB_API_HEADERS, "X-Group-Authorization": jeb_token}
 
+        print("\tFetching startups from JEB API...")
         response = requests.get(url, params=params, headers=headers)
         response.raise_for_status()
         startups_data = response.json()
@@ -285,6 +288,7 @@ def fetch_and_create_users():
         params = settings.JEB_API_DEFAULT_PARAMS
         headers = {**settings.JEB_API_HEADERS, "X-Group-Authorization": jeb_token}
 
+        print("\tFetching users from JEB API...")
         response = requests.get(url, params=params, headers=headers)
         response.raise_for_status()
         users_data = response.json()
@@ -340,6 +344,7 @@ def fetch_and_create_investors():
         params = settings.JEB_API_DEFAULT_PARAMS
         headers = {**settings.JEB_API_HEADERS, "X-Group-Authorization": jeb_token}
 
+        print("\tFetching investors from JEB API...")
         response = requests.get(url, params=params, headers=headers)
         response.raise_for_status()
         investors_data = response.json()
@@ -382,6 +387,7 @@ def fetch_and_create_partners():
         params = settings.JEB_API_DEFAULT_PARAMS
         headers = {**settings.JEB_API_HEADERS, "X-Group-Authorization": jeb_token}
 
+        print("\tFetching partners from JEB API...")
         response = requests.get(url, params=params, headers=headers)
         response.raise_for_status()
         partners_data = response.json()


### PR DESCRIPTION
This pull request introduces new user-related API endpoints, refactors user detail logic into a dedicated view, and makes several improvements to media URL handling and utility logging. The most significant changes are grouped below:

**User API endpoints and serialization:**

* Added `user_views.py` with `get_current_user` and `user_detail` endpoints, including a new `CurrentUserSerializer` for formatting authenticated user data. These endpoints provide current user info and user detail lookup, respectively. (`backend/exposed_api/user_views.py`)
* Updated `exposed_api/urls.py` to route user-related requests to the new `user_views` functions and removed the old user detail endpoint from `views.py`. (`backend/exposed_api/urls.py`) [[1]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bL3-R3) [[2]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bR15-L16)

**Refactoring and cleanup:**

* Removed the `user_detail` view from `views.py`, moving all user detail logic to `user_views.py` for better separation of concerns. (`backend/exposed_api/views.py`) [[1]](diffhunk://#diff-2caabcf82d64a294d9b932630f502192c444314d50516fe4cd75cd1b12f82fefL1-R4) [[2]](diffhunk://#diff-2caabcf82d64a294d9b932630f502192c444314d50516fe4cd75cd1b12f82fefL16) [[3]](diffhunk://#diff-2caabcf82d64a294d9b932630f502192c444314d50516fe4cd75cd1b12f82fefL31-L44)

**Media and image URL improvements:**

* Improved image/media URL handling in `event_serializers.py` to use `os.path.join` and `settings.MEDIA_URL`, ensuring correct URL formatting for event images. (`backend/exposed_api/event_serializers.py`) [[1]](diffhunk://#diff-42cccc915f23b5c542383f231a0e4bf8a6fea3c150369414e321bb315b867f6aR1-R3) [[2]](diffhunk://#diff-42cccc915f23b5c542383f231a0e4bf8a6fea3c150369414e321bb315b867f6aL24-R27)

**Utility logging enhancements:**

* Added print statements to the data-fetching functions in `init/utils.py` to log progress when fetching news, events, startups, users, investors, and partners from the JEB API. (`backend/init/utils.py`) [[1]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR76) [[2]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR118) [[3]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR247) [[4]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR291) [[5]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR347) [[6]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR390)

**Static/media serving configuration:**

* Fixed static media URL serving in `urls.py` by removing the `settings.DEBUG` condition, ensuring media files are always served correctly. (`backend/backend/urls.py`)