### PR TITLE
BACKEND - crud news

### DIFF
--- a/backend/exposed_api/news_views.py
+++ b/backend/exposed_api/news_views.py
@@ -1,12 +1,12 @@
+from authentication.permissions import IsAdmin
 from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.decorators import api_view, permission_classes
 
 from admin_panel.models import News, NewsDetail
-from admin_panel.serializers import NewsSerializer, NewsDetailSerializer
-from authentication.permissions import IsAdmin
+from admin_panel.serializers import NewsDetailSerializer, NewsSerializer
 
 
 class NewsListView(APIView):
@@ -34,8 +34,8 @@ class NewsListView(APIView):
         serializer = NewsDetailSerializer(data=request.data)
         if serializer.is_valid():
 
-            if 'image' in request.FILES:
-                serializer.validated_data['image'] = request.FILES['image']
+            if "image" in request.FILES:
+                serializer.validated_data["image"] = request.FILES["image"]
 
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -67,9 +67,7 @@ class NewsDetailView(APIView):
         """
         news = self.get_object(news_id)
         if not news:
-            return Response(
-                {"error": "News not found"}, status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"error": "News not found"}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = NewsDetailSerializer(news)
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -80,15 +78,13 @@ class NewsDetailView(APIView):
         """
         news = self.get_object(news_id)
         if not news:
-            return Response(
-                {"error": "News not found"}, status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"error": "News not found"}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = NewsDetailSerializer(news, data=request.data, partial=True)
         if serializer.is_valid():
 
-            if 'image' in request.FILES:
-                serializer.validated_data['image'] = request.FILES['image']
+            if "image" in request.FILES:
+                serializer.validated_data["image"] = request.FILES["image"]
 
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -100,9 +96,7 @@ class NewsDetailView(APIView):
         """
         news = self.get_object(news_id)
         if not news:
-            return Response(
-                {"error": "News not found"}, status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"error": "News not found"}, status=status.HTTP_404_NOT_FOUND)
 
         news.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/news_views.py
+++ b/backend/exposed_api/news_views.py
@@ -1,0 +1,108 @@
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.decorators import api_view, permission_classes
+
+from admin_panel.models import News, NewsDetail
+from admin_panel.serializers import NewsSerializer, NewsDetailSerializer
+from authentication.permissions import IsAdmin
+
+
+class NewsListView(APIView):
+    def get_permissions(self):
+        """
+        Override to return different permissions based on HTTP method.
+        GET requests are allowed for everyone, but POST requires admin.
+        """
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return [IsAdmin()]
+
+    def get(self, request):
+        """
+        List all news items, open to everyone
+        """
+        news = News.objects.all()
+        serializer = NewsSerializer(news, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        """
+        Create a new news item, only for admins
+        """
+        serializer = NewsDetailSerializer(data=request.data)
+        if serializer.is_valid():
+
+            if 'image' in request.FILES:
+                serializer.validated_data['image'] = request.FILES['image']
+
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class NewsDetailView(APIView):
+    def get_permissions(self):
+        """
+        Override to return different permissions based on HTTP method.
+        GET requests are allowed for everyone, but PUT and DELETE require admin.
+        """
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return [IsAdmin()]
+
+    def get_object(self, news_id):
+        """
+        Helper method to get the news detail object
+        """
+        try:
+            return NewsDetail.objects.get(id=news_id)
+        except NewsDetail.DoesNotExist:
+            return None
+
+    def get(self, request, news_id):
+        """
+        Retrieve a single news detail, open to everyone
+        """
+        news = self.get_object(news_id)
+        if not news:
+            return Response(
+                {"error": "News not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        serializer = NewsDetailSerializer(news)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def put(self, request, news_id):
+        """
+        Update a news item, only for admins
+        """
+        news = self.get_object(news_id)
+        if not news:
+            return Response(
+                {"error": "News not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        serializer = NewsDetailSerializer(news, data=request.data, partial=True)
+        if serializer.is_valid():
+
+            if 'image' in request.FILES:
+                serializer.validated_data['image'] = request.FILES['image']
+
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, news_id):
+        """
+        Delete a news item, only for admins
+        """
+        news = self.get_object(news_id)
+        if not news:
+            return Response(
+                {"error": "News not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        news.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from . import project_views, user_views, views
 from .event_views import EventListView
-from .news_views import NewsListView, NewsDetailView
+from .news_views import NewsDetailView, NewsListView
 
 app_name = "exposed_api"
 

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from . import project_views, user_views, views
 from .event_views import EventListView
+from .news_views import NewsListView, NewsDetailView
 
 app_name = "exposed_api"
 
@@ -12,6 +13,9 @@ urlpatterns = [
     path("projects/<int:_id>/", project_views.ProjectDetailView.as_view(), name="project_detail_or_crud"),
     # Events endpoint
     path("events/", EventListView.as_view(), name="events_list"),
+    # News endpoints
+    path("news/", NewsListView.as_view(), name="news_list"),
+    path("news/<int:news_id>/", NewsDetailView.as_view(), name="news_detail"),
     # User endpoints
     path("user/", user_views.get_current_user, name="current_user"),
     path("user/<int:user_id>/", user_views.user_detail, name="user_detail"),


### PR DESCRIPTION
This pull request introduces API endpoints for managing news items in the application, including both list and detail views, with appropriate permission handling for different HTTP methods. The endpoints allow public read access to news while restricting creation, update, and deletion to admin users.

**News API Endpoints Implementation:**

* Added `NewsListView` and `NewsDetailView` classes in `news_views.py` to provide endpoints for listing, creating, retrieving, updating, and deleting news items, with permission logic that allows public GET requests and restricts POST/PUT/DELETE to admins.
* Integrated the new news endpoints into the API routing in `urls.py`, adding routes for listing all news and accessing individual news items. [[1]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bR16-R18) [[2]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bR5)