### PR TITLE
BACKEND - CRUD for events

### DIFF
--- a/backend/exposed_api/event_views.py
+++ b/backend/exposed_api/event_views.py
@@ -1,3 +1,4 @@
+from authentication.permissions import IsAdmin
 from rest_framework import permissions, status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -8,11 +9,6 @@ from admin_panel.models import Event
 from .event_serializers import EventSerializer
 
 
-class IsAdminUser(permissions.BasePermission):
-    def has_permission(self, request, view):
-        return request.user and request.user.is_staff
-
-
 class EventListView(APIView):
     def get_permissions(self):
         """
@@ -21,10 +17,67 @@ class EventListView(APIView):
         """
         if self.request.method == "GET":
             return [AllowAny()]
-        return [IsAdminUser()]
+        return [IsAdmin()]
 
     def get(self, request):
+        """
+        List all events, open to everyone
+        """
         events = Event.objects.all()
         serializer = EventSerializer(events, many=True)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        """
+        Create a new event, only for admins
+        """
+        serializer = EventSerializer(data=request.data)
+        if serializer.is_valid():
+            if "image" in request.FILES:
+                serializer.validated_data["image"] = request.FILES["image"]
+
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class EventDetailView(APIView):
+    permission_classes = [IsAdmin]
+
+    def get_object(self, event_id):
+        """
+        Helper method to get the event object
+        """
+        try:
+            return Event.objects.get(id=event_id)
+        except Event.DoesNotExist:
+            return None
+
+    def put(self, request, event_id):
+        """
+        Update an event, only for admins
+        """
+        event = self.get_object(event_id)
+        if not event:
+            return Response({"error": "Event not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = EventSerializer(event, data=request.data, partial=True)
+        if serializer.is_valid():
+            if "image" in request.FILES:
+                serializer.validated_data["image"] = request.FILES["image"]
+
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, event_id):
+        """
+        Delete an event, only for admins
+        """
+        event = self.get_object(event_id)
+        if not event:
+            return Response({"error": "Event not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        event.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from . import project_views, user_views, views
-from .event_views import EventListView
+from .event_views import EventDetailView, EventListView
 from .news_views import NewsDetailView, NewsListView
 
 app_name = "exposed_api"
@@ -11,8 +11,9 @@ urlpatterns = [
     # Project endpoints
     path("projects/", project_views.ProjectDetailView.as_view(), name="project_create_or_list"),
     path("projects/<int:_id>/", project_views.ProjectDetailView.as_view(), name="project_detail_or_crud"),
-    # Events endpoint
+    # Events endpoints
     path("events/", EventListView.as_view(), name="events_list"),
+    path("events/<int:event_id>/", EventDetailView.as_view(), name="event_detail"),
     # News endpoints
     path("news/", NewsListView.as_view(), name="news_list"),
     path("news/<int:news_id>/", NewsDetailView.as_view(), name="news_detail"),


### PR DESCRIPTION
This pull request updates the event API endpoints to improve permissions handling and add full CRUD (Create, Read, Update, Delete) support for events. The changes ensure that only admin users can create, update, or delete events, while anyone can list events. The permission logic is also refactored to use a shared `IsAdmin` permission class.

**Event API improvements:**

* Replaced the custom `IsAdminUser` permission with the shared `IsAdmin` permission class for consistency and reuse. [[1]](diffhunk://#diff-d4625e224b4da4f99394a85ffcb589fabf565c10e84b734dbb303c3bdc8b6b42R1) [[2]](diffhunk://#diff-d4625e224b4da4f99394a85ffcb589fabf565c10e84b734dbb303c3bdc8b6b42L11-L15)
* Updated `EventListView` to allow anyone to list events (`GET`) but restrict event creation (`POST`) to admins.
* Added `EventDetailView` to support updating (`PUT`) and deleting (`DELETE`) events, restricted to admins only.

**Routing updates:**

* Registered new endpoint for single event operations (`/events/<int:event_id>/`) and updated imports accordingly. [[1]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bL4-R4) [[2]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bL14-R16)