### PR TITLE
Create the skeleton of the admin area with blank pages

### DIFF
--- a/frontend/app/admin/dashboard/page.tsx
+++ b/frontend/app/admin/dashboard/page.tsx
@@ -1,0 +1,32 @@
+import AdminNavigation from "@/components/AdminNavigation";
+
+
+export default function AdminDashboard() {
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-app-gradient-from to-app-gradient-to">
+            <AdminNavigation />
+
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="text-center mb-16">
+                    <h1 className="text-4xl md:text-5xl font-bold text-app-text-primary mb-6">
+                        Admin Dashboard
+                    </h1>
+                    <p className="text-xl text-app-text-secondary max-w-3xl mx-auto mb-8">
+                        Welcome to the admin management hub. Here you can manage platform content, users,
+                        and view key metrics about platform usage and engagement.
+                    </p>
+                </div>
+
+                {/* Dashboard content placeholder */}
+                <div className="max-w-6xl mx-auto">
+                    <div className="bg-app-surface rounded-lg shadow-md p-8">
+                        <h3 className="text-2xl font-semibold text-app-text-primary mb-6">Dashboard</h3>
+                        <p className="text-app-text-secondary mb-8">
+                            This is where the dashboard content will go.
+                        </p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/app/admin/events/page.tsx
+++ b/frontend/app/admin/events/page.tsx
@@ -1,0 +1,28 @@
+import AdminNavigation from "@/components/AdminNavigation";
+
+
+export default function AdminEvents() {
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-app-gradient-from to-app-gradient-to">
+            <AdminNavigation />
+
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="text-center mb-16">
+                    <h1 className="text-4xl md:text-5xl font-bold text-app-text-primary mb-6">
+                        Events Management
+                    </h1>
+                </div>
+
+                {/* Events content placeholder */}
+                <div className="max-w-6xl mx-auto">
+                    <div className="bg-app-surface rounded-lg shadow-md p-8">
+                        <h3 className="text-2xl font-semibold text-app-text-primary mb-6">Events</h3>
+                        <p className="text-app-text-secondary mb-8">
+                            This is where the events management content will go.
+                        </p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/app/admin/news/page.tsx
+++ b/frontend/app/admin/news/page.tsx
@@ -1,0 +1,28 @@
+import AdminNavigation from "@/components/AdminNavigation";
+
+
+export default function AdminNews() {
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-app-gradient-from to-app-gradient-to">
+            <AdminNavigation />
+
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="text-center mb-16">
+                    <h1 className="text-4xl md:text-5xl font-bold text-app-text-primary mb-6">
+                        News Management
+                    </h1>
+                </div>
+
+                {/* News content placeholder */}
+                <div className="max-w-6xl mx-auto">
+                    <div className="bg-app-surface rounded-lg shadow-md p-8">
+                        <h3 className="text-2xl font-semibold text-app-text-primary mb-6">News</h3>
+                        <p className="text-app-text-secondary mb-8">
+                            This is where the news management content will go.
+                        </p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/app/admin/projects/page.tsx
+++ b/frontend/app/admin/projects/page.tsx
@@ -1,0 +1,28 @@
+import AdminNavigation from "@/components/AdminNavigation";
+
+
+export default function AdminProjects() {
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-app-gradient-from to-app-gradient-to">
+            <AdminNavigation />
+
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="text-center mb-16">
+                    <h1 className="text-4xl md:text-5xl font-bold text-app-text-primary mb-6">
+                        Projects Management
+                    </h1>
+                </div>
+
+                {/* Projects content placeholder */}
+                <div className="max-w-6xl mx-auto">
+                    <div className="bg-app-surface rounded-lg shadow-md p-8">
+                        <h3 className="text-2xl font-semibold text-app-text-primary mb-6">Projects</h3>
+                        <p className="text-app-text-secondary mb-8">
+                            This is where the projects management content will go.
+                        </p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -1,0 +1,28 @@
+import AdminNavigation from "@/components/AdminNavigation";
+
+
+export default function AdminUsers() {
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-app-gradient-from to-app-gradient-to">
+            <AdminNavigation />
+
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="text-center mb-16">
+                    <h1 className="text-4xl md:text-5xl font-bold text-app-text-primary mb-6">
+                        Users Management
+                    </h1>
+                </div>
+
+                {/* Users content placeholder */}
+                <div className="max-w-6xl mx-auto">
+                    <div className="bg-app-surface rounded-lg shadow-md p-8">
+                        <h3 className="text-2xl font-semibold text-app-text-primary mb-6">Users</h3>
+                        <p className="text-app-text-secondary mb-8">
+                            This is where the users management content will go.
+                        </p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/components/AdminNavigation.tsx
+++ b/frontend/components/AdminNavigation.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { useState } from 'react';
+import { Menu, X } from 'lucide-react';
+
+export default function AdminNavigation() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const navItems = [
+    { href: '/admin/dashboard', label: 'Dashboard' },
+    { href: '/admin/projects', label: 'Projects' },
+    { href: '/admin/news', label: 'News' },
+    { href: '/admin/events', label: 'Events' },
+    { href: '/admin/users', label: 'Users' },
+  ];
+
+  const handleLogout = () => {
+    logout();
+    router.push('/');
+  };
+
+  const handleSwitchToPublic = () => {
+    router.push('/');
+  };
+
+  return (
+    <nav className="bg-white shadow-sm border-b">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16">
+          {/* Logo */}
+          <div className="flex items-center">
+            <Link href="/admin/dashboard" className="text-2xl font-bold text-blue-600">
+              JEB <span className="text-sm text-gray-500">Admin</span>
+            </Link>
+          </div>
+
+          {/* Desktop Navigation */}
+          <div className="hidden md:flex space-x-8 items-center">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={
+                  `transition-colors ${pathname === item.href
+                    ? 'text-blue-600 font-medium'
+                    : 'text-gray-600 hover:text-blue-600'}`
+                }
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+
+          {/* Desktop Actions */}
+          <div className="hidden md:flex items-center space-x-4">
+            <button
+              onClick={handleSwitchToPublic}
+              className="text-gray-600 hover:text-blue-600 transition-colors"
+            >
+              Public Area
+            </button>
+            <button
+              onClick={handleLogout}
+              className="font-bold text-gray-600 hover:text-red-600 transition-colors"
+            >
+              Logout
+            </button>
+          </div>
+
+          {/* Mobile menu button */}
+          <div className="md:hidden flex items-center">
+            <button
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              className="text-gray-600 hover:text-blue-600 focus:outline-none focus:text-blue-600 transition-colors"
+            >
+              {isMenuOpen ? (
+                <X className="h-6 w-6" />
+              ) : (
+                <Menu className="h-6 w-6" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile Navigation Menu */}
+        {isMenuOpen && (
+          <div className="md:hidden border-t border-gray-200 bg-white">
+            <div className="px-2 pt-2 pb-3 space-y-1">
+              {navItems.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setIsMenuOpen(false)}
+                  className={`block px-3 py-2 rounded-md text-base font-medium transition-colors ${pathname === item.href
+                    ? 'text-blue-600 bg-blue-50'
+                    : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50'
+                    }`}
+                >
+                  {item.label}
+                </Link>
+              ))}
+              <div className="border-t border-gray-200 pt-2 space-y-1">
+                <button
+                  onClick={() => {
+                    handleSwitchToPublic();
+                    setIsMenuOpen(false);
+                  }}
+                  className="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-blue-600 hover:bg-gray-50 transition-colors"
+                >
+                  Public Area
+                </button>
+                <button
+                  onClick={() => {
+                    handleLogout();
+                    setIsMenuOpen(false);
+                  }}
+                  className="block w-full text-left px-3 py-2 rounded-md text-base font-bold text-gray-600 hover:text-red-600 hover:bg-gray-50 transition-colors"
+                >
+                  Logout
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/components/Navigation.tsx
+++ b/frontend/components/Navigation.tsx
@@ -29,6 +29,10 @@ export default function Navigation() {
     router.push('/startup/dashboard');
   };
 
+  const handleSwitchToAdmin = () => {
+    router.push('/admin/dashboard');
+  }
+
   return (
     <nav className="bg-app-surface shadow-sm border-b">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -63,14 +67,22 @@ export default function Navigation() {
                 {user?.role === 'founder' && (
                   <button
                     onClick={handleSwitchToStartup}
-                    className="font-bold text-app-blue-primary hover:text-app-blue-primary-hover transition-colors"
+                    className="font-medium text-app-blue-primary hover:text-app-blue-primary-hover transition-colors cursor-pointer"
                     >
                     Startup Area
                   </button>
                 )}
+                {user?.role === 'admin' && (
+                  <button
+                    onClick={handleSwitchToAdmin}
+                    className="font-medium text-app-blue-primary hover:text-app-blue-primary-hover transition-colors cursor-pointer"
+                    >
+                    Admin Area
+                  </button>
+                )}
                 <button
                   onClick={handleLogout}
-                  className="font-bold text-app-text-secondary hover:text-app-red-primary transition-colors"
+                  className="font-bold text-app-text-secondary hover:text-app-red-primary transition-colors cursor-pointer"
                 >
                   Logout
                 </button>
@@ -118,15 +130,28 @@ export default function Navigation() {
               <div className="border-t border-app-border-light pt-2 space-y-1">
                 {isAuthenticated ? (
                   <>
-                    <button
-                      onClick={() => {
-                        handleSwitchToStartup();
-                        setIsMenuOpen(false);
-                      }}
-                      className="block w-full text-left px-3 py-2 rounded-md text-base font-bold text-app-blue-primary hover:text-app-blue-primary-hover hover:bg-app-blue-light transition-colors"
-                    >
-                      Startup Area
-                    </button>
+                    {user?.role === 'founder' && (
+                      <button
+                        onClick={() => {
+                          handleSwitchToStartup();
+                          setIsMenuOpen(false);
+                        }}
+                        className="block w-full text-left px-3 py-2 rounded-md text-base font-bold text-app-blue-primary hover:text-app-blue-primary-hover hover:bg-app-blue-light transition-colors"
+                      >
+                        Startup Area
+                      </button>
+                    )}
+                    {user?.role === 'admin' && (
+                      <button
+                        onClick={() => {
+                          handleSwitchToAdmin();
+                          setIsMenuOpen(false);
+                        }}
+                        className="block w-full text-left px-3 py-2 rounded-md text-base font-bold text-app-blue-primary hover:text-app-blue-primary-hover hover:bg-app-blue-light transition-colors"
+                      >
+                        Admin Area
+                      </button>
+                    )}
                     <button
                       onClick={() => {
                         handleLogout();


### PR DESCRIPTION
This pull request introduces a new admin section to the frontend, including navigation and placeholder pages for dashboard and management areas. It also updates the main navigation to allow admins to switch between the public and admin areas. The main themes are the addition of admin UI structure and improved navigation logic.

**Admin Section Implementation:**

* Added a reusable `AdminNavigation` component with desktop and mobile support, including navigation links for Dashboard, Projects, News, Events, and Users, as well as buttons for switching to the public area and logging out. (`frontend/components/AdminNavigation.tsx`)
* Created placeholder pages for admin dashboard and management areas (Projects, News, Events, Users), each using the new `AdminNavigation` and a consistent layout. (`frontend/app/admin/dashboard/page.tsx`, `frontend/app/admin/projects/page.tsx`, `frontend/app/admin/news/page.tsx`, `frontend/app/admin/events/page.tsx`, `frontend/app/admin/users/page.tsx`) [[1]](diffhunk://#diff-2d2ecc72e90ef679e3e995f449ba18e38736587a38e6cc90639fe6358e1aea40R1-R32) [[2]](diffhunk://#diff-49e46ef3e23fde7b397cd8b34a2c96290e11c1fd313f2609ddff83e16b47a369R1-R28) [[3]](diffhunk://#diff-f458b3499171811e6f04f668713b7915fb060cdffa771b4abe028aaf3ee5e9b0R1-R28) [[4]](diffhunk://#diff-f7da92f95f3ab4012cdd71c6d877494f9189043f0df86bddbeac6f74cb52e1eeR1-R28) [[5]](diffhunk://#diff-fa9e2d8187af833414eb3b96a4f7ce94b2556292244f2ae6e7a489f251a6fad2R1-R28)

**Navigation Enhancements:**

* Updated the main `Navigation` component to allow users with the admin role to switch to the admin dashboard from both desktop and mobile menus, mirroring the existing startup area switch for founders. (`frontend/components/Navigation.tsx`) [[1]](diffhunk://#diff-3d83074e496b24957634231bb472845243506378a12823d791b057fc0ed26a2bR32-R35) [[2]](diffhunk://#diff-3d83074e496b24957634231bb472845243506378a12823d791b057fc0ed26a2bL66-R85) [[3]](diffhunk://#diff-3d83074e496b24957634231bb472845243506378a12823d791b057fc0ed26a2bR133) [[4]](diffhunk://#diff-3d83074e496b24957634231bb472845243506378a12823d791b057fc0ed26a2bR143-R154)