### PR TITLE
feat(backend): CRUD for founders

### DIFF
--- a/backend/exposed_api/founder_serializers.py
+++ b/backend/exposed_api/founder_serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from admin_panel.models import Founder
+
+
+class FounderCrudSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Founder model CRUD operations.
+    """
+
+    class Meta:
+        model = Founder
+        fields = ["name", "id", "startup_id"]

--- a/backend/exposed_api/founder_views.py
+++ b/backend/exposed_api/founder_views.py
@@ -1,0 +1,58 @@
+from authentication.permissions import IsAdmin
+from django.http import JsonResponse
+from rest_framework import status
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from admin_panel.models import Founder
+
+from .founder_serializers import FounderCrudSerializer
+
+
+class FounderDetailView(APIView):
+    def get_permissions(self):
+        """
+        Override to return different permissions based on HTTP method.
+        GET requests are allowed for everyone, but POST, PUT, DELETE require admin.
+        """
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return [IsAdmin()]
+
+    def get(self, request, _id=None):
+        """Handle GET requests - accessible to all users"""
+        if _id is None:
+            founders = Founder.objects.all()
+            serializer = FounderCrudSerializer(founders, many=True)
+            return JsonResponse(serializer.data, safe=False)
+        try:
+            founder = Founder.objects.get(id=_id)
+            serializer = FounderCrudSerializer(founder)
+            return JsonResponse(serializer.data)
+        except Founder.DoesNotExist:
+            return JsonResponse({"error": f"Founder with id {_id} not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    def post(self, request):
+        """Handle POST requests - admin only"""
+        serializer = FounderCrudSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def put(self, request, _id):
+        """Handle PUT requests - admin only"""
+        founder = get_object_or_404(Founder, id=_id)
+        serializer = FounderCrudSerializer(founder, data=request.data, partial=False)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, _id):
+        """Handle DELETE requests - admin only"""
+        founder = get_object_or_404(Founder, id=_id)
+        founder.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/project_views.py
+++ b/backend/exposed_api/project_views.py
@@ -1,5 +1,6 @@
+from authentication.permissions import IsAdmin
 from django.http import JsonResponse
-from rest_framework import permissions, status
+from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny
@@ -29,11 +30,6 @@ def projects_by_founder(request, founder_id):
         return JsonResponse({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-class IsAdminUser(permissions.BasePermission):
-    def has_permission(self, request, view):
-        return request.user and request.user.is_staff
-
-
 class ProjectDetailView(APIView):
     def get_permissions(self):
         """
@@ -42,7 +38,7 @@ class ProjectDetailView(APIView):
         """
         if self.request.method == "GET":
             return [AllowAny()]
-        return [IsAdminUser()]
+        return [IsAdmin()]
 
     def get(self, request, _id=None):
         """Handle GET requests - accessible to all users"""

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from . import project_views, user_views, views
 from .event_views import EventDetailView, EventListView
+from .founder_views import FounderDetailView
 from .news_views import NewsDetailView, NewsListView
 
 app_name = "exposed_api"
@@ -18,6 +19,9 @@ urlpatterns = [
     # News endpoints
     path("news/", NewsListView.as_view(), name="news_list"),
     path("news/<int:news_id>/", NewsDetailView.as_view(), name="news_detail"),
+    # Founders endpoints
+    path("founders/", FounderDetailView.as_view(), name="founder_create_or_list"),
+    path("founders/<int:_id>/", FounderDetailView.as_view(), name="founder_detail_or_crud"),
     # User endpoints
     path("user/", user_views.get_current_user, name="current_user"),
     path("user/<int:user_id>/", user_views.user_detail, name="user_detail"),


### PR DESCRIPTION
This pull request introduces a new API endpoint for managing founders, including full CRUD operations, and refactors permission handling for admin-only actions in both founder and project views. The changes ensure consistent use of the custom `IsAdmin` permission class and expose the new founder endpoints via the API.

**New Founder API Endpoints:**

* Added `FounderDetailView` in `founder_views.py`, providing GET (list and detail), POST, PUT, and DELETE operations for the `Founder` model with appropriate permission checks (`AllowAny` for GET, `IsAdmin` for others).
* Introduced `FounderCrudSerializer` in `founder_serializers.py` to serialize `Founder` model data for CRUD operations.
* Registered new founder endpoints in `urls.py` for listing, creating, retrieving, updating, and deleting founders. [[1]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bR5) [[2]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bR22-R24)

**Permissions Refactoring:**

* Replaced the local `IsAdminUser` permission class in `project_views.py` with the shared `IsAdmin` class to standardize admin permission checks. [[1]](diffhunk://#diff-a80aaf5df8014aa3593b753f23f70afeb4ec7870354cecac24a338c15a82e22eR1-R3) [[2]](diffhunk://#diff-a80aaf5df8014aa3593b753f23f70afeb4ec7870354cecac24a338c15a82e22eL32-L36) [[3]](diffhunk://#diff-a80aaf5df8014aa3593b753f23f70afeb4ec7870354cecac24a338c15a82e22eL45-R41)