### PR TITLE
BACKEND -  CRUD for investors

### DIFF
--- a/backend/exposed_api/investor_serializers.py
+++ b/backend/exposed_api/investor_serializers.py
@@ -1,0 +1,24 @@
+from rest_framework import serializers
+
+from admin_panel.models import Investor
+
+
+class InvestorCrudSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Investor model CRUD operations.
+    """
+
+    class Meta:
+        model = Investor
+        fields = [
+            "name",
+            "legal_status",
+            "address",
+            "email",
+            "phone",
+            "created_at",
+            "description",
+            "investor_type",
+            "investment_focus",
+            "id",
+        ]

--- a/backend/exposed_api/investor_views.py
+++ b/backend/exposed_api/investor_views.py
@@ -1,0 +1,58 @@
+from authentication.permissions import IsAdmin
+from django.http import JsonResponse
+from rest_framework import status
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from admin_panel.models import Investor
+
+from .investor_serializers import InvestorCrudSerializer
+
+
+class InvestorDetailView(APIView):
+    def get_permissions(self):
+        """
+        Override to return different permissions based on HTTP method.
+        GET requests are allowed for everyone, but POST, PUT, DELETE require admin.
+        """
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return [IsAdmin()]
+
+    def get(self, request, _id=None):
+        """Handle GET requests - accessible to all users"""
+        if _id is None:
+            investors = Investor.objects.all()
+            serializer = InvestorCrudSerializer(investors, many=True)
+            return JsonResponse(serializer.data, safe=False)
+        try:
+            investor = Investor.objects.get(id=_id)
+            serializer = InvestorCrudSerializer(investor)
+            return JsonResponse(serializer.data)
+        except Investor.DoesNotExist:
+            return JsonResponse({"error": f"Investor with id {_id} not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    def post(self, request):
+        """Handle POST requests - admin only"""
+        serializer = InvestorCrudSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def put(self, request, _id):
+        """Handle PUT requests - admin only"""
+        investor = get_object_or_404(Investor, id=_id)
+        serializer = InvestorCrudSerializer(investor, data=request.data, partial=False)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, _id):
+        """Handle DELETE requests - admin only"""
+        investor = get_object_or_404(Investor, id=_id)
+        investor.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import project_views, user_views, views
 from .event_views import EventDetailView, EventListView
 from .founder_views import FounderDetailView
+from .investor_views import InvestorDetailView
 from .news_views import NewsDetailView, NewsListView
 
 app_name = "exposed_api"
@@ -22,6 +23,9 @@ urlpatterns = [
     # Founders endpoints
     path("founders/", FounderDetailView.as_view(), name="founder_create_or_list"),
     path("founders/<int:_id>/", FounderDetailView.as_view(), name="founder_detail_or_crud"),
+    # Investors endpoints
+    path("investors/", InvestorDetailView.as_view(), name="investor_create_or_list"),
+    path("investors/<int:_id>/", InvestorDetailView.as_view(), name="investor_detail_or_crud"),
     # User endpoints
     path("user/", user_views.get_current_user, name="current_user"),
     path("user/<int:user_id>/", user_views.user_detail, name="user_detail"),


### PR DESCRIPTION
This pull request introduces a new CRUD API for managing `Investor` objects in the backend. It adds both the serializer and view logic for handling investor data, and exposes new endpoints for these operations. The changes are grouped into API implementation and routing updates.

**API Implementation:**

* Added `InvestorCrudSerializer` in `investor_serializers.py` to serialize and validate `Investor` model data for all CRUD operations.
* Implemented `InvestorDetailView` in `investor_views.py`, supporting GET (list and detail, open to all), POST, PUT, and DELETE (admin only), with appropriate permission checks and error handling.

**Routing Updates:**

* Registered `InvestorDetailView` in `urls.py` and added two new endpoints: one for listing/creating investors and one for retrieving/updating/deleting by ID. [[1]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bR6) [[2]](diffhunk://#diff-55adfb44b3ca2b09391449b8dfa0aea11484a67c0f4781a47a3b5afa68e4fb2bR26-R28)