### PR TITLE
BACKEND - CRUD for partners

### DIFF
--- a/backend/exposed_api/partner_serializers.py
+++ b/backend/exposed_api/partner_serializers.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+
+from admin_panel.models import Partner
+
+
+class PartnerCrudSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Partner model CRUD operations.
+    """
+
+    class Meta:
+        model = Partner
+        fields = [
+            "name",
+            "legal_status",
+            "address",
+            "email",
+            "phone",
+            "created_at",
+            "description",
+            "partnership_type",
+            "id",
+        ]

--- a/backend/exposed_api/partner_views.py
+++ b/backend/exposed_api/partner_views.py
@@ -1,0 +1,58 @@
+from authentication.permissions import IsAdmin
+from django.http import JsonResponse
+from rest_framework import status
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from admin_panel.models import Partner
+
+from .partner_serializers import PartnerCrudSerializer
+
+
+class PartnerDetailView(APIView):
+    def get_permissions(self):
+        """
+        Override to return different permissions based on HTTP method.
+        GET requests are allowed for everyone, but POST, PUT, DELETE require admin.
+        """
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return [IsAdmin()]
+
+    def get(self, request, _id=None):
+        """Handle GET requests - accessible to all users"""
+        if _id is None:
+            partners = Partner.objects.all()
+            serializer = PartnerCrudSerializer(partners, many=True)
+            return JsonResponse(serializer.data, safe=False)
+        try:
+            partner = Partner.objects.get(id=_id)
+            serializer = PartnerCrudSerializer(partner)
+            return JsonResponse(serializer.data)
+        except Partner.DoesNotExist:
+            return JsonResponse({"error": f"Partner with id {_id} not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    def post(self, request):
+        """Handle POST requests - admin only"""
+        serializer = PartnerCrudSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def put(self, request, _id):
+        """Handle PUT requests - admin only"""
+        partner = get_object_or_404(Partner, id=_id)
+        serializer = PartnerCrudSerializer(partner, data=request.data, partial=False)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, _id):
+        """Handle DELETE requests - admin only"""
+        partner = get_object_or_404(Partner, id=_id)
+        partner.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/urls.py
+++ b/backend/exposed_api/urls.py
@@ -5,6 +5,7 @@ from .event_views import EventDetailView, EventListView
 from .founder_views import FounderDetailView
 from .investor_views import InvestorDetailView
 from .news_views import NewsDetailView, NewsListView
+from .partner_views import PartnerDetailView
 
 app_name = "exposed_api"
 
@@ -26,6 +27,9 @@ urlpatterns = [
     # Investors endpoints
     path("investors/", InvestorDetailView.as_view(), name="investor_create_or_list"),
     path("investors/<int:_id>/", InvestorDetailView.as_view(), name="investor_detail_or_crud"),
+    # Partners endpoints
+    path("partners/", PartnerDetailView.as_view(), name="partner_create_or_list"),
+    path("partners/<int:_id>/", PartnerDetailView.as_view(), name="partner_detail_or_crud"),
     # User endpoints
     path("user/", user_views.get_current_user, name="current_user"),
     path("user/<int:user_id>/", user_views.user_detail, name="user_detail"),


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) API support for the `Partner` model in the exposed API, including a new serializer, view, and URL routes. The implementation ensures that read operations are open to all users, while modifications require admin permissions.

**Partner API CRUD functionality:**

* Added `PartnerCrudSerializer` for serializing and deserializing `Partner` model data, supporting all relevant fields.
* Implemented `PartnerDetailView` with methods for GET (list and detail, public), POST, PUT, and DELETE (admin only), handling permissions and error responses appropriately.

**Routing and integration:**

* Registered new URL routes for listing/creating partners and for retrieving/updating/deleting individual partners in `urls.py`.
* Imported the new view in the API module's URL configuration.