### PR TITLE
fix(page): translate error messages and labels to English in ProjectExportPage

### DIFF
--- a/frontend/app/projects/export-pdf/[token]/page.tsx
+++ b/frontend/app/projects/export-pdf/[token]/page.tsx
@@ -32,7 +32,7 @@ export default function ProjectExportPage() {
 
     useEffect(() => {
         if (!token) {
-            setError("Token d'authentification manquant");
+            setError("Authentication token missing");
             setLoading(false);
             return;
         }
@@ -58,14 +58,14 @@ export default function ProjectExportPage() {
                 );
                 
                 if (!userResponse.ok) {
-                    throw new Error('Erreur d\'authentification');
+                    throw new Error('Authentication error');
                 }
                 
                 const userData = await userResponse.json();
                 const founderId = userData.founderId;
                 
                 if (!founderId) {
-                    throw new Error('Aucun ID de fondateur associé à cet utilisateur');
+                    throw new Error('No founder ID associated with this user');
                 }
                 
                 const projectResponse = await authenticatedFetch(
@@ -75,13 +75,13 @@ export default function ProjectExportPage() {
                 );
                 
                 if (!projectResponse.ok) {
-                    throw new Error('Impossible de récupérer les projets');
+                    throw new Error('Unable to retrieve projects');
                 }
                 
                 const projects = await projectResponse.json();
                 
                 if (!projects || projects.length === 0) {
-                    throw new Error('Aucun projet trouvé pour ce fondateur');
+                    throw new Error('No projects found for this founder');
                 }
                 
                 setProject(projects[0]);
@@ -112,8 +112,8 @@ export default function ProjectExportPage() {
                     }
                 }
             } catch (error) {
-                console.error("Erreur lors de la récupération des données:", error);
-                setError(error instanceof Error ? error.message : 'Erreur inconnue');
+                console.error("Error retrieving data:", error);
+                setError(error instanceof Error ? error.message : 'Unknown error');
             } finally {
                 setLoading(false);
             }
@@ -123,14 +123,14 @@ export default function ProjectExportPage() {
     }, [token]);
     
     if (loading) {
-        return <div className="flex justify-center items-center h-screen">Chargement des données du projet...</div>;
+        return <div className="flex justify-center items-center h-screen">Loading project data...</div>;
     }
 
     if (error || !project) {
         return (
             <div className="flex justify-center items-center h-screen flex-col">
-                <div className="text-xl font-bold text-red-500">Erreur</div>
-                <div className="mt-2">{error || "Données du projet non disponibles"}</div>
+                <div className="text-xl font-bold text-red-500">Error</div>
+                <div className="mt-2">{error || "Project data not available"}</div>
             </div>
         );
     }
@@ -142,9 +142,9 @@ export default function ProjectExportPage() {
                     {/* Header */}
                     <header className="mb-12 text-center">
                         <h1 className="text-5xl font-extrabold text-gray-900">{project.ProjectName}</h1>
-                        <p className="text-xl text-gray-500 mt-2">Rapport de Performance du Projet</p>
+                        <p className="text-xl text-gray-500 mt-2">Project Performance Report</p>
                         <Badge variant="secondary" className="mt-4 text-base">
-                            ID du Projet: {project.ProjectId}
+                            Project ID: {project.ProjectId}
                         </Badge>
                     </header>
                     {/* Main Content */}
@@ -152,7 +152,7 @@ export default function ProjectExportPage() {
                         {/* Project Details & Founders */}
                         <Card className="mb-8 border-2 border-gray-200 shadow-lg">
                             <CardHeader className="bg-gray-50">
-                                <CardTitle className="text-2xl">Détails du Projet</CardTitle>
+                                <CardTitle className="text-2xl">Project Details</CardTitle>
                             </CardHeader>
                             <CardContent className="p-6 grid grid-cols-1 md:grid-cols-3 gap-6">
                                 <div className="md:col-span-2 space-y-4">
@@ -163,11 +163,11 @@ export default function ProjectExportPage() {
                                         <Badge className="bg-purple-100 text-purple-800">{project.ProjectLegalStatus}</Badge>
                                         <Badge className="bg-yellow-100 text-yellow-800">{project.ProjectStatus}</Badge>
                                     </div>
-                                    <p><span className="font-semibold">Adresse:</span> {project.ProjectAddress}</p>
-                                    <p><span className="font-semibold">Créé le:</span> {new Date(project.ProjectCreatedAt).toLocaleDateString('fr-FR')}</p>
+                                    <p><span className="font-semibold">Address:</span> {project.ProjectAddress}</p>
+                                    <p><span className="font-semibold">Created on:</span> {new Date(project.ProjectCreatedAt).toLocaleDateString('en-US')}</p>
                                 </div>
                                 <div className="space-y-4">
-                                    <h3 className="font-bold text-lg">Fondateurs</h3>
+                                    <h3 className="font-bold text-lg">Founders</h3>
                                     {project.ProjectFounders.map(founder => (
                                         <div key={founder.FounderID} className="flex items-center gap-3">
                                             <Avatar>
@@ -185,22 +185,22 @@ export default function ProjectExportPage() {
                         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
                             <Card className="shadow-md">
                                 <CardHeader>
-                                    <CardTitle>Vues du Projet par Mois</CardTitle>
+                                    <CardTitle>Project Views by Month</CardTitle>
                                 </CardHeader>
                                 <CardContent>
                                     <ChartBarLabel
                                         data={views}
                                         title=""
-                                        description="Vues mensuelles du projet"
-                                        footerTitle="Tendance"
-                                        footerDescription="Analyse de la croissance des vues"
-                                        config={{ views: { label: "Vues", color: "#3b82f6" } }}
+                                        description="Monthly project views"
+                                        footerTitle="Trend"
+                                        footerDescription="Analysis of view growth"
+                                        config={{ views: { label: "Views", color: "#3b82f6" } }}
                                     />
                                 </CardContent>
                             </Card>
                             <Card className="shadow-md">
                                 <CardHeader>
-                                    <CardTitle>Taux d&apos;Engagement</CardTitle>
+                                    <CardTitle>Engagement Rate</CardTitle>
                                 </CardHeader>
                                 <CardContent>
                                     <ChartRadialText
@@ -210,12 +210,12 @@ export default function ProjectExportPage() {
                                             fill: "#8b5cf6"
                                         }]}
                                         title=""
-                                        description="Métriques d'engagement actuelles"
+                                        description="Current engagement metrics"
                                         centerLabel="Engagement"
                                         footerTitle="Performance"
                                         footerDescription={engagement?.rate?.toString() || "0"}
                                         endAngle={(engagement?.rate || 0) * 360 / 100}
-                                        config={{ rate: { label: "Taux" }, engagement: { label: "Engagement", color: "#8b5cf6" } }}
+                                        config={{ rate: { label: "Rate" }, engagement: { label: "Engagement", color: "#8b5cf6" } }}
                                     />
                                 </CardContent>
                             </Card>
@@ -223,7 +223,7 @@ export default function ProjectExportPage() {
                     </main>
                     {/* Footer */}
                     <footer className="text-center text-gray-500 pt-8 mt-8 border-t">
-                        Rapport généré le {new Date().toLocaleDateString('fr-FR')}
+                        Report generated on {new Date().toLocaleDateString('fr-FR')}
                     </footer>
                 </div>
     );


### PR DESCRIPTION
This pull request updates the `frontend/app/projects/export-pdf/[token]/page.tsx` file to fully translate the user interface and error messages from French to English, ensuring a consistent experience for English-speaking users. The changes affect error handling, loading states, UI labels, and chart descriptions.

**Internationalization and UI Text Updates:**

* All error messages, loading states, and UI labels in `ProjectExportPage` have been translated from French to English for consistency and improved accessibility. ([frontend/app/projects/export-pdf/[token]/page.tsxL35-R35](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L35-R35), [frontend/app/projects/export-pdf/[token]/page.tsxL61-R68](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L61-R68), [frontend/app/projects/export-pdf/[token]/page.tsxL78-R84](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L78-R84), [frontend/app/projects/export-pdf/[token]/page.tsxL115-R116](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L115-R116), [frontend/app/projects/export-pdf/[token]/page.tsxL126-R133](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L126-R133), [frontend/app/projects/export-pdf/[token]/page.tsxL145-R155](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L145-R155), [frontend/app/projects/export-pdf/[token]/page.tsxL166-R170](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L166-R170), [frontend/app/projects/export-pdf/[token]/page.tsxL188-R203](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L188-R203), [frontend/app/projects/export-pdf/[token]/page.tsxL213-R226](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L213-R226))

**Date Formatting and Localization:**

* The date format for project creation has been changed from French (`fr-FR`) to US English (`en-US`) for the "Created on" field, while the footer date remains in French format. ([frontend/app/projects/export-pdf/[token]/page.tsxL166-R170](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L166-R170), [frontend/app/projects/export-pdf/[token]/page.tsxL213-R226](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L213-R226))

**Chart and Metric Labels:**

* Chart titles, descriptions, and metric labels have been updated to English, including "Project Views by Month," "Monthly project views," and "Engagement Rate," among others. ([frontend/app/projects/export-pdf/[token]/page.tsxL188-R203](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L188-R203), [frontend/app/projects/export-pdf/[token]/page.tsxL213-R226](diffhunk://#diff-ac8844e8775c1e4e7794e66adf0d7e5d3c758aca7593a9f6d9bc8f3aae3befd8L213-R226))