### PR TITLE
feat(password-visibility): add toggle for password visibility in ResetPasswordConfirmForm

### DIFF
--- a/frontend/components/ResetPasswordConfirmForm.tsx
+++ b/frontend/components/ResetPasswordConfirmForm.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { getAPIUrl } from "@/lib/config";
+import { LuEye, LuEyeClosed } from "react-icons/lu";
 
 interface ResetPasswordConfirmFormProps {
   token: string;
@@ -26,6 +27,8 @@ export function ResetPasswordConfirmForm({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -114,27 +117,77 @@ export function ResetPasswordConfirmForm({
                 )}
                 <div className="grid gap-3">
                   <Label htmlFor="password">Password</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    placeholder="••••••••"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                    disabled={isLoading}
-                  />
+                  <div className="relative">
+                    <Input
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      placeholder="••••••••"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                      disabled={isLoading}
+                    />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-opacity duration-200"
+                      onClick={() => setShowPassword(!showPassword)}
+                      aria-label={showPassword ? "Hide password" : "Show password"}
+                    >
+                      <div className="relative w-5 h-5">
+                        <LuEyeClosed 
+                          className={`absolute transition-all duration-300 ${
+                            showPassword 
+                              ? "opacity-100 transform scale-100" 
+                              : "opacity-0 transform scale-75"
+                          }`} 
+                        />
+                        <LuEye 
+                          className={`absolute transition-all duration-300 ${
+                            showPassword 
+                              ? "opacity-0 transform scale-75" 
+                              : "opacity-100 transform scale-100"
+                          }`} 
+                        />
+                      </div>
+                    </button>
+                  </div>
                 </div>
                 <div className="grid gap-3">
                   <Label htmlFor="confirm-password">Confirm Password</Label>
-                  <Input
-                    id="confirm-password"
-                    type="password"
-                    placeholder="••••••••"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    required
-                    disabled={isLoading}
-                  />
+                  <div className="relative">
+                    <Input
+                      id="confirm-password"
+                      type={showConfirmPassword ? "text" : "password"}
+                      placeholder="••••••••"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      required
+                      disabled={isLoading}
+                    />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-opacity duration-200"
+                      onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                      aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+                    >
+                      <div className="relative w-5 h-5">
+                        <LuEyeClosed 
+                          className={`absolute transition-all duration-300 ${
+                            showConfirmPassword 
+                              ? "opacity-100 transform scale-100" 
+                              : "opacity-0 transform scale-75"
+                          }`} 
+                        />
+                        <LuEye 
+                          className={`absolute transition-all duration-300 ${
+                            showConfirmPassword 
+                              ? "opacity-0 transform scale-75" 
+                              : "opacity-100 transform scale-100"
+                          }`} 
+                        />
+                      </div>
+                    </button>
+                  </div>
                 </div>
                 <Button
                   type="submit"


### PR DESCRIPTION
This pull request enhances the user experience of the `ResetPasswordConfirmForm` component by adding password visibility toggles for both the password and confirm password fields. This allows users to easily view or hide their input, reducing errors when setting a new password.

**UI/UX improvements:**

* Added state variables `showPassword` and `showConfirmPassword` to control the visibility of the password and confirm password fields.
* Updated both password input fields to conditionally render as `"text"` or `"password"` based on their respective visibility state.
* Added toggle buttons with eye icons (`LuEye` and `LuEyeClosed` from `react-icons/lu`) next to each password field, allowing users to show or hide their input. The button includes accessibility labels and smooth transitions for icon changes. [[1]](diffhunk://#diff-1d2103babe9cc0a799d542363c8438778c80db55b5a20eb98727bbbc024622bcR16) [[2]](diffhunk://#diff-1d2103babe9cc0a799d542363c8438778c80db55b5a20eb98727bbbc024622bcR120-R190)