### PR TITLE
BACKEND - unfound images are not an error

### DIFF
--- a/backend/init/utils.py
+++ b/backend/init/utils.py
@@ -51,14 +51,14 @@ def fetch_with_retry(url, headers=None, params=None, max_retries=3, retry_delay=
             last_exception = e
             retries += 1
             if retries < max_retries:
-                if not (allow_404 and hasattr(e, 'response') and e.response.status_code == 404):
+                if not (allow_404 and hasattr(e, "response") and e.response.status_code == 404):
                     logging.warning(f"Request failed for {url}, retrying ({retries}/{max_retries})...")
                 time.sleep(retry_delay)
 
-    if not (allow_404 and hasattr(last_exception, 'response') and last_exception.response.status_code == 404):
+    if not (allow_404 and hasattr(last_exception, "response") and last_exception.response.status_code == 404):
         logging.error(f"All {max_retries} retry attempts failed for {url}")
 
-    if allow_404 and hasattr(last_exception, 'response') and last_exception.response.status_code == 404:
+    if allow_404 and hasattr(last_exception, "response") and last_exception.response.status_code == 404:
         return None
 
     raise last_exception

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ ignore = [
     "ARG002",   # Unused function argument
     "C901",   # Function is too complex
     "PLR0915",  # Too many statements
+    "PLR0913",  # Too many arguments
 ]
 
 # Allow autofix for all enabled rules (when '--fix') is provided


### PR DESCRIPTION
This pull request improves the handling of image fetching in several data import functions by allowing graceful handling of missing images (HTTP 404 responses). The main change is an update to the `fetch_with_retry` utility function to support an `allow_404` parameter, which lets the caller skip missing images without raising errors. This enhancement is applied across multiple functions that fetch images for news, events, founders, and users.

**Image fetching robustness:**

* Added an `allow_404` parameter to the `fetch_with_retry` function in `backend/init/utils.py`, allowing callers to receive `None` instead of raising an exception when a 404 response is encountered. [[1]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aL20-R20) [[2]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR30-R33) [[3]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aR44-R63)
* Updated image fetching logic in `fetch_news_detail`, `fetch_and_create_events`, `fetch_startup_detail`, and `fetch_and_create_users` to use `allow_404=True` and only process images if they exist, preventing errors due to missing images. [[1]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aL79-R92) [[2]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aL175-R189) [[3]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aL244-R259) [[4]](diffhunk://#diff-7ee24fd02874687e24f40f0f52b2029bd1f61703114d7cda8a9ef1d3f604612aL347-R363)