### PR TITLE
BACKEND - Fix auditlog error

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -90,9 +90,7 @@ def update_user_profile(request):
     if serializer.is_valid():
         user = serializer.save()
 
-        AuditLog.objects.create(
-            action=f"User profile updated: {user.name}", user=user.name, type="user"
-        )
+        AuditLog.objects.create(action=f"User profile updated: {user.name}", user=user.name, type="user")
 
         return Response(serializer.data)
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -195,9 +193,7 @@ def reset_password_confirm(request):
     if serializer.is_valid():
         user = serializer.save()
 
-        AuditLog.objects.create(
-            action=f"Password reset completed: {user.name}", user=user.name, type="user"
-        )
+        AuditLog.objects.create(action=f"Password reset completed: {user.name}", user=user.name, type="user")
 
         return Response({"detail": "Your password has been successfully reset."}, status=status.HTTP_200_OK)
 

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -49,7 +49,7 @@ def register_user(request):
         stats.new_signups += 1
         stats.save()
 
-        AuditLog.objects.create(action=f"New user registered: {user.name} ({user.email})", user=user.name, type="user")
+        AuditLog.objects.create(action=f"New user registered: {user.name}", user=user.name, type="user")
 
         refresh = RefreshToken.for_user(user)
 
@@ -91,7 +91,7 @@ def update_user_profile(request):
         user = serializer.save()
 
         AuditLog.objects.create(
-            action=f"User profile updated: {user.name} ({user.email})", user=user.name, type="user"
+            action=f"User profile updated: {user.name}", user=user.name, type="user"
         )
 
         return Response(serializer.data)
@@ -196,7 +196,7 @@ def reset_password_confirm(request):
         user = serializer.save()
 
         AuditLog.objects.create(
-            action=f"Password reset completed: {user.name} ({user.email})", user=user.name, type="user"
+            action=f"Password reset completed: {user.name}", user=user.name, type="user"
         )
 
         return Response({"detail": "Your password has been successfully reset."}, status=status.HTTP_200_OK)

--- a/backend/exposed_api/event_views.py
+++ b/backend/exposed_api/event_views.py
@@ -40,9 +40,7 @@ class EventListView(APIView):
 
             event = serializer.save()
 
-            AuditLog.objects.create(
-                action=f"New event created: {event.name}", user=request.user.name, type="event"
-            )
+            AuditLog.objects.create(action=f"New event created: {event.name}", user=request.user.name, type="event")
 
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/exposed_api/event_views.py
+++ b/backend/exposed_api/event_views.py
@@ -41,7 +41,7 @@ class EventListView(APIView):
             event = serializer.save()
 
             AuditLog.objects.create(
-                action=f"New event created: {event.name}", user=request.user.username, type="event"
+                action=f"New event created: {event.name}", user=request.user.name, type="event"
             )
 
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -76,7 +76,7 @@ class EventDetailView(APIView):
             updated_event = serializer.save()
 
             AuditLog.objects.create(
-                action=f"Event updated: {updated_event.name}", user=request.user.username, type="event"
+                action=f"Event updated: {updated_event.name}", user=request.user.name, type="event"
             )
 
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -91,7 +91,7 @@ class EventDetailView(APIView):
             return Response({"error": "Event not found"}, status=status.HTTP_404_NOT_FOUND)
 
         event_name = event.name
-        AuditLog.objects.create(action=f"Event deleted: {event_name}", user=request.user.username, type="event")
+        AuditLog.objects.create(action=f"Event deleted: {event_name}", user=request.user.name, type="event")
 
         event.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/news_views.py
+++ b/backend/exposed_api/news_views.py
@@ -39,9 +39,7 @@ class NewsListView(APIView):
                 serializer.validated_data["image"] = request.FILES["image"]
 
             news = serializer.save()
-            AuditLog.objects.create(
-                action=f"New news item created: {news.title}", user=request.user.name, type="news"
-            )
+            AuditLog.objects.create(action=f"New news item created: {news.title}", user=request.user.name, type="news")
 
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/exposed_api/news_views.py
+++ b/backend/exposed_api/news_views.py
@@ -40,7 +40,7 @@ class NewsListView(APIView):
 
             news = serializer.save()
             AuditLog.objects.create(
-                action=f"New news item created: {news.title}", user=request.user.username, type="news"
+                action=f"New news item created: {news.title}", user=request.user.name, type="news"
             )
 
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -93,7 +93,7 @@ class NewsDetailView(APIView):
 
             updated_news = serializer.save()
             AuditLog.objects.create(
-                action=f"News item updated: {updated_news.title}", user=request.user.username, type="news"
+                action=f"News item updated: {updated_news.title}", user=request.user.name, type="news"
             )
 
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -108,7 +108,7 @@ class NewsDetailView(APIView):
             return Response({"error": "News not found"}, status=status.HTTP_404_NOT_FOUND)
 
         news_title = news.title
-        AuditLog.objects.create(action=f"News item deleted: {news_title}", user=request.user.username, type="news")
+        AuditLog.objects.create(action=f"News item deleted: {news_title}", user=request.user.name, type="news")
 
         news.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/exposed_api/project_views.py
+++ b/backend/exposed_api/project_views.py
@@ -70,7 +70,7 @@ class ProjectDetailView(APIView):
 
             AuditLog.objects.create(
                 action=f"New project created: {serializer.validated_data.get('name')}",
-                user=request.user.username,
+                user=request.user.name,
                 type="project",
             )
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -85,7 +85,7 @@ class ProjectDetailView(APIView):
 
             AuditLog.objects.create(
                 action=f"Project updated: {serializer.validated_data.get('name')}",
-                user=request.user.username,
+                user=request.user.name,
                 type="project",
             )
             return Response(serializer.data)
@@ -98,7 +98,7 @@ class ProjectDetailView(APIView):
         project.delete()
         AuditLog.objects.create(
             action=f"Project deleted: {project_name}",
-            user=request.user.username,
+            user=request.user.name,
             type="project",
         )
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
This pull request standardizes how user information is logged in the `AuditLog` across authentication, event, news, and project views. The main changes are the removal of user email from authentication-related audit logs and switching from `request.user.username` to `request.user.name` for event, news, and project audit logs. This ensures consistency and better privacy in audit entries.

**Authentication audit log improvements:**

* Removed user email from audit log actions for user registration, profile updates, and password resets in `backend/authentication/views.py` for improved privacy. [[1]](diffhunk://#diff-9940c9d38bc6c38719cc958928969af345e336ce5aba35b004e36141715d514bL52-R52) [[2]](diffhunk://#diff-9940c9d38bc6c38719cc958928969af345e336ce5aba35b004e36141715d514bL94-R94) [[3]](diffhunk://#diff-9940c9d38bc6c38719cc958928969af345e336ce5aba35b004e36141715d514bL199-R199)

**Audit log user field consistency:**

* Changed audit log entries to use `request.user.name` instead of `request.user.username` when logging actions for events in `backend/exposed_api/event_views.py`. [[1]](diffhunk://#diff-d4625e224b4da4f99394a85ffcb589fabf565c10e84b734dbb303c3bdc8b6b42L44-R44) [[2]](diffhunk://#diff-d4625e224b4da4f99394a85ffcb589fabf565c10e84b734dbb303c3bdc8b6b42L79-R79) [[3]](diffhunk://#diff-d4625e224b4da4f99394a85ffcb589fabf565c10e84b734dbb303c3bdc8b6b42L94-R94)
* Updated audit log entries to use `request.user.name` for news actions in `backend/exposed_api/news_views.py`. [[1]](diffhunk://#diff-35d32efd5d615ec6677beb9879576556c9bad884e051a0d7f2fa47e5a7c0e08cL43-R43) [[2]](diffhunk://#diff-35d32efd5d615ec6677beb9879576556c9bad884e051a0d7f2fa47e5a7c0e08cL96-R96) [[3]](diffhunk://#diff-35d32efd5d615ec6677beb9879576556c9bad884e051a0d7f2fa47e5a7c0e08cL111-R111)
* Updated audit log entries to use `request.user.name` for project actions in `backend/exposed_api/project_views.py`. [[1]](diffhunk://#diff-a80aaf5df8014aa3593b753f23f70afeb4ec7870354cecac24a338c15a82e22eL73-R73) [[2]](diffhunk://#diff-a80aaf5df8014aa3593b753f23f70afeb4ec7870354cecac24a338c15a82e22eL88-R88) [[3]](diffhunk://#diff-a80aaf5df8014aa3593b753f23f70afeb4ec7870354cecac24a338c15a82e22eL101-R101)