### PR TITLE
feat(backend): add is_active field to AdminUserSerializer for user ma…

### DIFF
--- a/backend/exposed_api/user_views.py
+++ b/backend/exposed_api/user_views.py
@@ -56,10 +56,11 @@ class AdminUserSerializer(serializers.ModelSerializer):
     role = serializers.ChoiceField(choices=CustomUser.ROLE_CHOICES)
     founder = serializers.SerializerMethodField()
     userImage = serializers.SerializerMethodField()
+    is_active = serializers.BooleanField()
 
     class Meta:
         model = CustomUser
-        fields = ["id", "name", "email", "role", "founder", "userImage"]
+        fields = ["id", "name", "email", "role", "founder", "userImage", "is_active"]
 
     def get_founder(self, obj):
         if obj.role == "founder" and obj.founder_id:


### PR DESCRIPTION
This pull request introduces a minor update to the `AdminUserSerializer` in the `backend/exposed_api/user_views.py` file. The change adds support for the `is_active` field, allowing the serializer to expose a user's active status in API responses.

* Added `is_active` as a `BooleanField` to the `AdminUserSerializer` and included it in the serializer's output fields.…nagement