### PR TITLE
fix(serializer): enhance picture URL retrieval logic in FounderDetail…

### DIFF
--- a/backend/exposed_api/founder_serializers.py
+++ b/backend/exposed_api/founder_serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
 
 from admin_panel.models import Founder, StartupDetail
+from django.conf import settings
+import os
 
 
 class FounderCrudSerializer(serializers.ModelSerializer):
@@ -35,7 +37,11 @@ class FounderDetailSerializer(serializers.ModelSerializer):
         try:
             startup = StartupDetail.objects.get(id=obj.startup_id)
             if startup.founders_images and isinstance(startup.founders_images, dict):
-                return startup.founders_images.get(str(obj.id))
+                picture_path = startup.founders_images.get(str(obj.id))
+                if picture_path:
+                    if not picture_path.startswith("/"):
+                        return os.path.join(settings.MEDIA_URL.rstrip("/"), picture_path)
+                    return picture_path
             return None
         except StartupDetail.DoesNotExist:
             return None


### PR DESCRIPTION
This pull request updates the logic for generating founder picture URLs in the `FounderCrudSerializer` to ensure proper handling of relative and absolute paths. The main change is the addition of logic to prepend the media URL to relative image paths, improving consistency in how founder images are referenced.

Enhancements to founder image URL handling:

* Updated `get_FounderPictureURL` to check if the image path is relative and prepend `settings.MEDIA_URL` when necessary, ensuring correct URL formation for founder images.
* Imported `settings` and `os` in `backend/exposed_api/founder_serializers.py` to support the new path handling logic.…Serializer