### PR TITLE
fix(user): ensure correct image URL formatting in user image serializers

### DIFF
--- a/backend/exposed_api/serializers.py
+++ b/backend/exposed_api/serializers.py
@@ -387,7 +387,10 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_pictureURL(self, obj):
         if obj.image:
-            return f"{settings.MEDIA_URL}{obj.image}"
+            image_path = obj.image
+            if image_path.startswith('/'):
+                image_path = image_path[1:]
+            return f"{settings.MEDIA_URL.rstrip('/')}/{image_path}"
         return None
 
     def get_nbStartups(self, obj):

--- a/backend/exposed_api/user_views.py
+++ b/backend/exposed_api/user_views.py
@@ -42,7 +42,10 @@ class CurrentUserSerializer(serializers.ModelSerializer):
 
     def get_userImage(self, obj):
         if obj.image:
-            return f"{settings.MEDIA_URL}{obj.image}"
+            image_path = obj.image
+            if image_path.startswith('/'):
+                image_path = image_path[1:]
+            return f"{settings.MEDIA_URL.rstrip('/')}/{image_path}"
         return None
 
 
@@ -73,7 +76,11 @@ class AdminUserSerializer(serializers.ModelSerializer):
 
     def get_userImage(self, obj):
         if obj.image:
-            return f"{settings.MEDIA_URL}{obj.image}"
+            # Make sure the path doesn't have double slashes
+            image_path = obj.image
+            if image_path.startswith('/'):
+                image_path = image_path[1:]
+            return f"{settings.MEDIA_URL.rstrip('/')}/{image_path}"
         return None
 
 


### PR DESCRIPTION
This pull request standardizes how image URLs are constructed in the backend, ensuring that there are no double slashes in the resulting URLs. The changes update the logic for building image URLs in both serializer and view methods to strip any leading slash from the image path and ensure the media URL does not end with a slash.

**Image URL construction improvements:**

* Updated `get_pictureURL` in `Meta` class (`backend/exposed_api/serializers.py`) to remove any leading slash from `obj.image` and ensure `settings.MEDIA_URL` does not end with a trailing slash when constructing the image URL.
* Updated `get_userImage` in `backend/exposed_api/user_views.py` (used in multiple places) to use the same logic for building image URLs, preventing double slashes and ensuring consistent formatting. [[1]](diffhunk://#diff-1d2deeaf76785f5abb5f97d4d141f9690cb82b9b1ae07c7a042e699183f98358L45-R48) [[2]](diffhunk://#diff-1d2deeaf76785f5abb5f97d4d141f9690cb82b9b1ae07c7a042e699183f98358L76-R83)