### PR TITLE
fix(permissions): update access control to include founders for speci…

### DIFF
--- a/backend/exposed_api/kpi_views.py
+++ b/backend/exposed_api/kpi_views.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from auditlog.models import AuditLog
 from authentication.models import CustomUser
-from authentication.permissions import IsAdmin
+from authentication.permissions import IsAdmin, IsAdminOrFounder
 from django.db.models import Count, F, Q
 from django.db.models.functions import TruncDay, TruncMonth
 from django.http import JsonResponse
@@ -63,11 +63,11 @@ def new_signups(request):
 
 
 @api_view(["GET"])
-@permission_classes([IsAdmin])
+@permission_classes([IsAdminOrFounder])
 def projects_visibility(request):
     """
     API endpoint that returns project visibility data by month.
-    This endpoint requires admin privileges.
+    This endpoint requires admin or founder privileges.
     """
     now = timezone.now()
     last_6_months = now - timedelta(days=180)
@@ -188,13 +188,13 @@ def monthly_stats(request):
 
 
 @api_view(["GET"])
-@permission_classes([IsAdmin])
+@permission_classes([IsAdminOrFounder])
 def project_view_stats(request, project_id=None):
     """
     API endpoint that returns view statistics for projects.
     If project_id is provided, returns stats for that specific project.
     Otherwise, returns stats for all projects.
-    This endpoint requires admin privileges.
+    This endpoint requires admin or founder privileges.
     """
     period = request.GET.get("period", "all")
 
@@ -239,11 +239,11 @@ def project_view_stats(request, project_id=None):
 
 
 @api_view(["GET"])
-@permission_classes([IsAdmin])
+@permission_classes([IsAdminOrFounder])
 def most_viewed_projects(request):
     """
     API endpoint that returns the most viewed projects.
-    This endpoint requires admin privileges.
+    This endpoint requires admin or founder privileges.
     """
     period = request.GET.get("period", "month")
     limit = int(request.GET.get("limit", 5))
@@ -288,13 +288,13 @@ def most_viewed_projects(request):
 
 
 @api_view(["GET"])
-@permission_classes([IsAdmin])
+@permission_classes([IsAdminOrFounder])
 def project_views_over_time(request, project_id=None):
     """
     API endpoint that returns project views over time.
     If project_id is provided, returns data for that specific project.
     Otherwise, returns aggregated data for all projects.
-    This endpoint requires admin privileges.
+    This endpoint requires admin or founder privileges.
     """
     grouping = request.GET.get("grouping", "month")
     period = request.GET.get("period", "year")

--- a/backend/exposed_api/views.py
+++ b/backend/exposed_api/views.py
@@ -72,10 +72,10 @@ def project_views(request, user_id):
     Returns the views of the user's projects for the last 6 months.
     This is a placeholder implementation.
     Restricted to authenticated users with roles other than regular users.
-    Users can only access their own data unless they are admins.
+    Users can only access their own data unless they are admins or founders.
     """
-    # Check if user is accessing their own data or is an admin
-    if str(request.user.id) != str(user_id) and request.user.role != "admin":
+    # Check if user is accessing their own data or is an admin/founder
+    if str(request.user.id) != str(user_id) and request.user.role not in ["admin", "founder"]:
         return Response({"error": "You do not have permission to access this data"}, status=status.HTTP_403_FORBIDDEN)
 
     # Placeholder data
@@ -99,10 +99,10 @@ def project_engagement(request, user_id):
     Returns the engagement rate for the user's projects.
     This is a placeholder implementation.
     Restricted to authenticated users with roles other than regular users.
-    Users can only access their own data unless they are admins.
+    Users can only access their own data unless they are admins or founders.
     """
-    # Check if user is accessing their own data or is an admin
-    if str(request.user.id) != str(user_id) and request.user.role != "admin":
+    # Check if user is accessing their own data or is an admin/founder
+    if str(request.user.id) != str(user_id) and request.user.role not in ["admin", "founder"]:
         return Response({"error": "You do not have permission to access this data"}, status=status.HTTP_403_FORBIDDEN)
 
     # Placeholder data


### PR DESCRIPTION
This pull request expands access permissions for several KPI and project-related API endpoints to include both admins and founders, instead of restricting access to admins only. The changes affect both the permission decorators and the internal role checks in relevant view functions.

**Access Control Updates:**

* Changed permission decorators in `backend/exposed_api/kpi_views.py` to use `IsAdminOrFounder` instead of `IsAdmin` for endpoints related to project visibility, view statistics, most viewed projects, and views over time. This allows founders to access these endpoints in addition to admins. [[1]](diffhunk://#diff-5a1b376d4246d0827d0a572066b69463e32d9a4d867fc7db8ff1dad34d804ac2L5-R5) [[2]](diffhunk://#diff-5a1b376d4246d0827d0a572066b69463e32d9a4d867fc7db8ff1dad34d804ac2L66-R70) [[3]](diffhunk://#diff-5a1b376d4246d0827d0a572066b69463e32d9a4d867fc7db8ff1dad34d804ac2L191-R197) [[4]](diffhunk://#diff-5a1b376d4246d0827d0a572066b69463e32d9a4d867fc7db8ff1dad34d804ac2L242-R246) [[5]](diffhunk://#diff-5a1b376d4246d0827d0a572066b69463e32d9a4d867fc7db8ff1dad34d804ac2L291-R297)

**Role Check Logic Improvements:**

* Updated internal role checks in `project_views` and `project_engagement` functions in `backend/exposed_api/views.py` to grant access to founders as well as admins, ensuring that both roles can view and engage with user project data beyond their own. [[1]](diffhunk://#diff-2caabcf82d64a294d9b932630f502192c444314d50516fe4cd75cd1b12f82fefL75-R78) [[2]](diffhunk://#diff-2caabcf82d64a294d9b932630f502192c444314d50516fe4cd75cd1b12f82fefL102-R105)…fic endpoints