### PR TITLE
fix(record-project-view): prevent counting views by founders on their…

### DIFF
--- a/backend/exposed_api/views.py
+++ b/backend/exposed_api/views.py
@@ -32,11 +32,14 @@ def record_project_view(request, project_id):
     """
     try:
         project = StartupDetail.objects.get(id=project_id)
-
         user = request.user if request.user.is_authenticated else None
-        if user and user.role == "founder" and user.founder_id is not None:
-            if project.founders.filter(id=user.founder_id).exists():
-                return True
+        if (
+            user
+            and user.role == "founder"
+            and user.founder_id is not None
+            and project.founders.filter(id=user.founder_id).exists()
+        ):
+            return True
 
         x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
         ip_address = x_forwarded_for.split(",")[0] if x_forwarded_for else request.META.get("REMOTE_ADDR")


### PR DESCRIPTION
This pull request updates the logic for recording project views to prevent founders from incrementing view counts on their own projects. The main change ensures that if the authenticated user is a founder and is associated with the project, their view is not counted.

Logic update to view recording:

* In `record_project_view` in `backend/exposed_api/views.py`, added a check to skip counting the view if the authenticated user is a founder and is one of the project's founders.
* Updated the function docstring to clarify that views are not counted when a founder views their own project.

Imports:

* Imported the `Founder` model in `backend/exposed_api/views.py` to support the new founder-related logic.… own projects