### PR TITLE
Fixed the favicon disappearing

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,6 +33,7 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/app/favicon.ico ./app/favicon.ico
 
 RUN mkdir -p /home/nextjs/.cache/puppeteer && \
     chown -R nextjs:nodejs /home/nextjs/.cache && \


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process for the frontend. The change ensures that the favicon is copied into the container with the correct ownership, which can help prevent permission issues when the application is running.

* Dockerfile: Added a line to copy `app/favicon.ico` from the build output to the container, setting the owner to `nextjs:nodejs`.