### PR TITLE
today's cell is now in the color palette's theme

### DIFF
--- a/frontend/components/Calendar.tsx
+++ b/frontend/components/Calendar.tsx
@@ -174,16 +174,12 @@ const Calendar: React.FC<CalendarProps> = ({ events, onEventClick }) => {
                 <div
                   key={`day-${index}`}
                   className={`p-1 sm:p-2 h-16 sm:h-20 lg:h-24 border border-app-border-light rounded transition-colors hover:bg-app-surface-hover ${
-                    isTodayDay
-                      ? "bg-app-blue-light border-app-blue-primary"
-                      : "bg-app-surface"
+                    isTodayDay ? "bg-jeb-light/50" : "bg-app-surface"
                   }`}
                 >
                   <div
                     className={`font-medium text-xs sm:text-sm mb-1 ${
-                      isTodayDay
-                        ? "text-app-blue-primary"
-                        : "text-app-text-primary"
+                      isTodayDay ? "text-jeb-primary" : "text-app-text-primary"
                     }`}
                   >
                     {day}


### PR DESCRIPTION
This pull request updates the visual styling of the current day in the `Calendar` component to use the new `jeb` color palette, improving consistency with the application's updated design system.

**UI theme updates:**

* Changed the background color for the current day from `bg-app-blue-light` to `bg-jeb-light/50` in the calendar grid.
* Updated the text color for the current day from `text-app-blue-primary` to `text-jeb-primary`.