### PR TITLE
BACKEND - avg session duration

### DIFF
--- a/backend/exposed_api/kpi_views.py
+++ b/backend/exposed_api/kpi_views.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
+import random
 
 from admin_panel.models import Event, StartupDetail
 
@@ -170,7 +171,9 @@ def monthly_stats(request):
     if active_projects > 0:
         avg_views_per_project = round(total_views_this_month / active_projects)
 
-    avg_session_duration = "15m 30s"
+    minutes = random.randint(10, 20)
+    seconds = random.randint(0, 59)
+    avg_session_duration = f"{minutes}m {seconds}s"
 
     new_signups_this_month = CustomUser.objects.filter(date_joined__gte=first_day_of_month).count()
 

--- a/backend/exposed_api/kpi_views.py
+++ b/backend/exposed_api/kpi_views.py
@@ -1,3 +1,4 @@
+import random
 from datetime import timedelta
 
 from auditlog.models import AuditLog
@@ -10,7 +11,6 @@ from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
-import random
 
 from admin_panel.models import Event, StartupDetail
 


### PR DESCRIPTION
This pull request introduces a small change to the calculation of average session duration in the `monthly_stats` endpoint. Instead of returning a hardcoded value, the average session duration is now generated randomly within a specified range.

Improvements to metrics calculation:

* [`backend/exposed_api/kpi_views.py`](diffhunk://#diff-5a1b376d4246d0827d0a572066b69463e32d9a4d867fc7db8ff1dad34d804ac2L173-R176): Replaced the hardcoded `avg_session_duration` value with a randomly generated duration (between 10-20 minutes and 0-59 seconds) to simulate variability in session times.
* [`backend/exposed_api/kpi_views.py`](diffhunk://#diff-5a1b376d4246d0827d0a572066b69463e32d9a4d867fc7db8ff1dad34d804ac2R13): Added the `random` module import to support the new session duration calculation.