### PR TITLE
FRONTEND - force light theme as default

### DIFF
--- a/frontend/contexts/ThemeContext.tsx
+++ b/frontend/contexts/ThemeContext.tsx
@@ -15,15 +15,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
-    // Check for saved theme preference or default to light mode
-    const savedTheme = localStorage.getItem("theme") as Theme;
-    if (savedTheme) {
-      setTheme(savedTheme);
-    } else {
-      // Check system preference
-      const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      setTheme(systemPrefersDark ? "dark" : "light");
-    }
+    setTheme("light");
+    const root = window.document.documentElement;
+    root.classList.remove("dark");
+    root.classList.add("light");
+    localStorage.setItem("theme", "light");
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request updates the theme initialization logic in the `ThemeProvider` component to always default to light mode, removing support for saved user preferences and system dark mode detection.

Theme management changes:

* The `ThemeProvider` component now sets the theme to `"light"` by default, removes the `"dark"` class from the root element, adds the `"light"` class, and saves `"light"` to `localStorage`, eliminating the previous logic that checked for saved preferences or system dark mode. (`frontend/contexts/ThemeContext.tsx`, [frontend/contexts/ThemeContext.tsxL18-R22](diffhunk://#diff-856ce94467f1317d80223a915cb5bd4b500b0c7deaf383a421e24837645468d4L18-R22))