### PR TITLE
Fixed ProjectDetailsGetWithLikesSerializer fields

### DIFF
--- a/backend/exposed_api/serializers.py
+++ b/backend/exposed_api/serializers.py
@@ -175,7 +175,7 @@ class ProjectDetailGetWithLikesSerializer(ProjectDetailGetSerializer):
     likes_count = serializers.IntegerField(source="nb_likes", read_only=True)
 
     class Meta(ProjectDetailGetSerializer.Meta):
-        fields = ProjectDetailGetSerializer.Meta.fields
+        fields = ProjectDetailGetSerializer.Meta.fields.copy()
         fields.append("likes_count")
 
 


### PR DESCRIPTION
This pull request makes a minor update to the `ProjectDetailGetWithLikesSerializer` class in `backend/exposed_api/serializers.py`, ensuring that the `fields` list is copied before appending the new `likes_count` field. This prevents unintended side effects from modifying the original fields list.

* Copied the `fields` list from `ProjectDetailGetSerializer.Meta` before appending `"likes_count"` to avoid mutating the original fields list.