### PR TITLE
fix(ProjectDetails): comment out ProjectId display logic

### DIFF
--- a/frontend/components/ProjectDetails.tsx
+++ b/frontend/components/ProjectDetails.tsx
@@ -429,17 +429,6 @@ Shared from JEB Incubator
             </h2>
 
             <div className="space-y-3 sm:space-y-4 md:space-y-6">
-              {/* {props.ProjectId && (
-                <div>
-                  <dt className="text-xs sm:text-xs md:text-sm font-medium text-app-text-muted mb-0.5 sm:mb-1 md:mb-2">
-                    Project ID
-                  </dt>
-                  <dd className="text-sm sm:text-base md:text-lg text-app-text-primary">
-                    #{props.ProjectId}
-                  </dd>
-                </div>
-              )} */}
-
               {props.ProjectLegalStatus && (
                 <div>
                   <dt className="text-xs sm:text-xs md:text-sm font-medium text-app-text-muted mb-0.5 sm:mb-1 md:mb-2">

--- a/frontend/components/ProjectDetails.tsx
+++ b/frontend/components/ProjectDetails.tsx
@@ -429,7 +429,7 @@ Shared from JEB Incubator
             </h2>
 
             <div className="space-y-3 sm:space-y-4 md:space-y-6">
-              {props.ProjectId && (
+              {/* {props.ProjectId && (
                 <div>
                   <dt className="text-xs sm:text-xs md:text-sm font-medium text-app-text-muted mb-0.5 sm:mb-1 md:mb-2">
                     Project ID
@@ -438,7 +438,7 @@ Shared from JEB Incubator
                     #{props.ProjectId}
                   </dd>
                 </div>
-              )}
+              )} */}
 
               {props.ProjectLegalStatus && (
                 <div>


### PR DESCRIPTION
This pull request makes a minor UI change to the `ProjectDetails` component. The display of the `ProjectId` field has been commented out, so it will no longer appear in the rendered output.

* Commented out the conditional rendering block for the `ProjectId` field in `frontend/components/ProjectDetails.tsx`, effectively hiding the Project ID from the UI. [[1]](diffhunk://#diff-c66d0115ba24a07dc7d6173d1769de9575f0d600d09044da44eb2984945f5d38L432-R432) [[2]](diffhunk://#diff-c66d0115ba24a07dc7d6173d1769de9575f0d600d09044da44eb2984945f5d38L441-R441)